### PR TITLE
catch downstream kokkos dependency

### DIFF
--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -12,6 +12,9 @@ class PortsOfCall(CMakePackage, CudaPackage):
     version("main", branch="main")
     variant("doc", default=False, description="Sphinx Documentation Support")
     variant("portability_strategy", description="Portability strategy backend",
+            values=("Kokkos","Cuda","None"),multi=False,default="kokkos",
+            when="^kokkos")
+    variant("portability_strategy", description="Portability strategy backend",
             values=("Kokkos","Cuda","None"),multi=False,default="none")
 
     depends_on("cmake@3.12:")

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -12,10 +12,10 @@ class PortsOfCall(CMakePackage, CudaPackage):
     version("main", branch="main")
     variant("doc", default=False, description="Sphinx Documentation Support")
     variant("portability_strategy", description="Portability strategy backend",
-            values=("Kokkos","Cuda","None"),multi=False,default="kokkos",
+            values=("Kokkos","Cuda","None"),multi=False,default="Kokkos",
             when="^kokkos")
     variant("portability_strategy", description="Portability strategy backend",
-            values=("Kokkos","Cuda","None"),multi=False,default="none")
+            values=("Kokkos","Cuda","None"),multi=False,default="None")
 
     depends_on("cmake@3.12:")
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As suggested by @mauneyc-LANL this let's the spackage for ports of call catch the kokkos dependency for packages that depend on ports-of-call..

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [x] Install test passes.
- [x] Docs build.
