### PR TITLE
Sync spackage with spack upstream version

### DIFF
--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -1,18 +1,26 @@
-# Spackage for Ports of Call
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
 
+
 class PortsOfCall(CMakePackage, CudaPackage):
-    """ports-of-call"""
+    """Ports of Call: Performance Portability Utilities"""
 
     homepage    = "https://github.com/lanl/ports-of-call"
-    url         = "https://github.com/lanl/ports-of-call/archive/refs/heads/main.zip"
-    git         = "git@github.com:lanl/ports-of-call.git"
+    url         = "https://github.com/lanl/ports-of-call/archive/refs/tags/v1.1.0.tar.gz"
+    git         = "https://github.com/lanl/ports-of-call.git"
+
+    maintainers = ['rbberger']
 
     version("main", branch="main")
+    version('1.1.0', sha256='c47f7e24c82176b69229a2bcb23a6adcf274dc90ec77a452a36ccae0b12e6e39')
+
     variant("doc", default=False, description="Sphinx Documentation Support")
     variant("portability_strategy", description="Portability strategy backend",
-            values=("Kokkos","Cuda","None"),multi=False,default="None")
+            values=("Kokkos", "Cuda", "None"), multi=False, default="None")
 
     depends_on("cmake@3.12:")
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Update Spack package for `ports-of-call`to the one now present in Spack upstream

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
