### PR TITLE
cmake config guard for submodule mode

### DIFF
--- a/ports-of-callConfig.cmake.in
+++ b/ports-of-callConfig.cmake.in
@@ -5,6 +5,8 @@
 
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@POCLIB@Targets.cmake")
+if(NOT TARGET @POCLIB@ AND NOT @POCLIB@_BINARY_DIR)
+  include("${CMAKE_CURRENT_LIST_DIR}/@POCLIB@Targets.cmake")
+endif()
 
 check_required_components(@POCLIB@)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

If used as in-tree as a submodule downstream, cmake will `include()` a file generated by `export()`, which generates an error (see https://cmake.org/cmake/help/v3.17/policy/CMP0024.html). This includes a guard against invoking the `include()` in the scenario when `ports-of-call` is not the main project. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

This fixes an issue encountered when `singularity-eos` cmake configuration was re-run after the initial cmake generate step. In this case, importing `spiner` submodule would use the prior `export()`-ed `ports-of-callConfig.cmake` that was present in the build directory. Due to CMP0024 (above), this would produce an error, and the build directory would need to be cleaned to produce a usable configuration.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
