### PR TITLE
package registry docs

### DIFF
--- a/doc/sphinx/src/building.rst
+++ b/doc/sphinx/src/building.rst
@@ -57,8 +57,7 @@ attempt disabling the package registry at configure time via
 
   -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF
 
-For more details, see the documentation on the `cmake package
-registry`_.
+For more details, see the documentation on the `cmake package registry`_.
 
 .. _cmake package registry: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#package-registry
 

--- a/doc/sphinx/src/building.rst
+++ b/doc/sphinx/src/building.rst
@@ -33,6 +33,26 @@ For in-tree builds, you can set the configure time option
 ``PORTABILITY_STRATEGY`` to ``Kokkos``, ``Cuda`` or ``None`` to set
 the equivalent preprocessor macro. The default is ``None``.
 
+By default ``cmake`` keeps a registry of packages with install logic
+that it has built in a user's home directory. Because
+``ports-of-call`` fixes portability strategy at ``cmake`` configure
+time, this can conflict with in-tree builds. A parent code that
+includes ``ports-of-call`` may find the wrong build by default, rather
+than the version that it includes explicitly in the source tree. To
+resolve this, we recommend disabling ``cmake``'s package registry
+machinery via:
+
+.. code-block:: cmake
+
+  set(CMAKE_FIND_USE_PACKAGE_REGISTRY OFF CACHE BOOL "" FORCE)
+  set(CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY OFF CACHE BOOL "" FORCE)
+
+If, on the other hand, you install the dependencies of your code one-by-one,
+you should not disable the package registry. For more details, see the
+documentation on the `cmake package registry`_.
+
+.. _cmake package registry: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#package-registry
+
 Spack
 ^^^^^^
 

--- a/doc/sphinx/src/building.rst
+++ b/doc/sphinx/src/building.rst
@@ -47,9 +47,18 @@ machinery via:
   set(CMAKE_FIND_USE_PACKAGE_REGISTRY OFF CACHE BOOL "" FORCE)
   set(CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY OFF CACHE BOOL "" FORCE)
 
-If, on the other hand, you install the dependencies of your code one-by-one,
-you should not disable the package registry. For more details, see the
-documentation on the `cmake package registry`_.
+If, on the other hand, you install the dependencies of your code
+one-by-one, you should not disable the package registry. If you
+encounter an issue where your configuration settings for
+``ports-of-call`` don't seem to stick when building a code, you might
+attempt disabling the package registry at configure time via
+
+.. code-block:: cmake
+
+  -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF
+
+For more details, see the documentation on the `cmake package
+registry`_.
 
 .. _cmake package registry: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#package-registry
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I have been bit multiple times by the `cmake` package registry pulling out a globally installed version of `ports-of-call` rather than the in-tree version I would like to use. Here I just add some documentation for `ports-of-call` explaining how to handle this issue in downstream codes.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
