### PR TITLE
Add 1D and 2D parallel reduces

### DIFF
--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -178,6 +178,35 @@ void portableFor(const char *name, int startb, int stopb, int starta, int stopa,
 }
 
 template <typename Function, typename T>
+void portableReduce(const char *name, int start, int stop, Function function,
+                    T &reduced) {
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  using Policy = Kokkos::RangePolicy<>;
+  Kokkos::parallel_reduce(name, Policy(start, stop), function, reduced);
+#else
+  for (int i = start; i < stop; i++) {
+    function(i, reduced);
+  }
+#endif
+}
+
+template <typename Function, typename T>
+void portableReduce(const char *name, int starty, int stopy, int startx,
+                    int stopx, Function function, T &reduced) {
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  using Policy2D = Kokkos::MDRangePolicy<Kokkos::Rank<2>>;
+  Kokkos::parallel_reduce(name, Policy2D({starty, startx}, {stopy, stopx}),
+                          function, reduced);
+#else
+  for (int iy = starty; iy < stopy; iy++) {
+    for (int ix = startx; ix < stopx; ix++) {
+      function(iy, ix, reduced);
+    }
+  }
+#endif
+}
+
+template <typename Function, typename T>
 void portableReduce(const char *name, int startz, int stopz, int starty,
                     int stopy, int startx, int stopx, Function function,
                     T &reduced) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

`parallelReduce` didn't support 1D or 2D. This PR adds those overloads.

Fixes #14 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [x] Install test passes.
- [ ] Docs build.
