### PR TITLE
spack: Remove +doc variant and dependencies

### DIFF
--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -19,14 +19,4 @@ class PortsOfCall(CMakePackage):
     version('1.2.0', sha256='b802ffa07c5f34ea9839f23841082133d8af191efe5a526cb7e53ec338ac146b')
     version('1.1.0', sha256='c47f7e24c82176b69229a2bcb23a6adcf274dc90ec77a452a36ccae0b12e6e39')
 
-    variant("doc", default=False, description="Sphinx Documentation Support")
     depends_on("cmake@3.12:")
-
-    depends_on("py-sphinx", when="+doc")
-    depends_on("py-sphinx-rtd-theme@0.4.3", when="+doc")
-    depends_on("py-sphinx-multiversion", when="+doc")
-
-    def cmake_args(self):
-        args = [
-        ]
-        return args


### PR DESCRIPTION
## PR Summary

The current CMake setup doesn't do anything with it.

Should be readded in case CMake is extended to build the documentation and install it.

Closes #18

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
