### PR TITLE
add portable error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${POCLIB}Config.cmake
 install(
   FILES "${CMAKE_CURRENT_SOURCE_DIR}/ports-of-call/portability.hpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/ports-of-call/portable_arrays.hpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/ports-of-call/portable_errors.hpp"
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${POCLIB}
 )
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We define a few portability macros which are useful:
 At compile time, you define `PORTABILITY_STRATEGY_{KOKKOS,CUDA,NONE}` (if you don't
 define it, it defaults to NONE).
 
-There are to be two headers in this folder, for different use cases.
+There are several headers in this folder, for different use cases.
 
 ### portability.hpp
 
@@ -28,6 +28,10 @@ There are to be two headers in this folder, for different use cases.
 provides device malloc/device free operations. This is the principle
 path for turning on/off Kokkos. 
 - Provides loop abstractions that can be leveraged by the code.  
+
+### portable_errors.hpp
+
+- Provides portable macros for error handling on both host and device.
 
 ### portable_array.hpp:
 

--- a/doc/sphinx/src/developing.rst
+++ b/doc/sphinx/src/developing.rst
@@ -3,7 +3,7 @@
 Developing Ports of Call
 ========================
 
-As Ports of Call is only two small header files, not much is
+As Ports of Call is only a few small header files, not much is
 required. We do require the files be formatted using
 ``clang-format``. The format version is pinned 12. Please call
 ```clang-format`` on your files before merging them.

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -84,23 +84,19 @@ line number where the macro was called, enabling easier debugging.
 The following macros are **disabled** automaticaly for production
 builds (e.g., when the ``NDEBUG`` preprocessor macro is defined):
 
-* ``PORTABLE_REQUIRE(condition, message)`` prints an error message and aborts the program (without throwing an exception) if compiled in debug mode and ``condition`` is not satisfied. This macro **works** in device kernels.
-* ``PORTABLE_REQUIRE_THROWS(condition, message)`` raises a runtime exception (annotated with the message) when compiled in debug mode and the condition is not satisfied. This macro **does not** work in device kernels.
-* ``PORTABLE_ABORT(message)`` prints an error message and aborts the program when compiled in debug mode. This macro **works** in device kernels.
-* ``PORTABLE_THROW(message)`` prints an error message and raises a runtime exception when compiled in debug mode. This macro **does not** work in device kernels.
-* ``PORTABLE_WARN(message)`` prints a warning message if compiled in debug mode. This macro **works** in device kernels.
-* ``PORTABLE_THROW_OR_ABORT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. As with the above portable, this macro is **disabled in production.** This macro **works** in device kernels.
+* ``PORTABLE_REQUIRE(condition, message)`` prints an error message and aborts the program (without throwing an exception) if compiled in debug mode and ``condition`` is not satisfied.
+* ``PORTABLE_ABORT(message)`` prints an error message and aborts the program when compiled in debug mode.
+* ``PORTABLE_WARN(message)`` prints a warning message if compiled in debug mode.
+* ``PORTABLE_THROW_OR_ABORT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. This macro is disabled in production.
 
 Each of the above macros is **disabled** and becomes a no-op for most builds and only enabled for ``Debug`` builds. However, for each of the above macros there is an equivalent ``PORTABLE_ALWAYS_*`` macro, which **always** functions and is **never** a no-op:
 
-* ``PORTABLE_ALWAYS_REQUIRE(condition, message)`` prints an error message and aborts the program (without throwing an exception) if ``condition`` is not satisfied. This macro **works** in device kernels.
-* ``PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)`` raises a runtime exception (annotated with the message) when the condition is not satisfied. This macro **does not** work in device kernels.
-* ``PORTABLE_ALWAYS_ABORT(message)`` prints an error message and aborts the program. This macro **works** in device kernels.
-* ``PORTABLE_ALWAYS_THROW(message)`` prints an error message and raises a runtime exception. This macro **does not** work in device kernels.
-* ``PORTABLE_ALWAYS_WARN(message)`` prints a warning message. This macro **works** in device kernels.
-* ``PORTABLE_ALWAYS_THROW_OR_ABORT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. This macro **works** in device kernels.
+* ``PORTABLE_ALWAYS_REQUIRE(condition, message)`` prints an error message and aborts the program (without throwing an exception) if ``condition`` is not satisfied.
+* ``PORTABLE_ALWAYS_ABORT(message)`` prints an error message and aborts the program.
+* ``PORTABLE_ALWAYS_WARN(message)`` prints a warning message.
+* ``PORTABLE_ALWAYS_THROW_OR_ABORT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception.
 
-Please note that none of these functions are thread or MPI aware. Iin a parallel program, the same message may be called **many times**. Therefore caution should be used with this machinery and you may wish to hide these macros in if statements, for example,
+Please note that none of these functions are thread or MPI aware. In a parallel program, the same message may be called **many times**. Therefore caution should be used with this machinery and you may wish to hide these macros in if statements, for example,
 
 .. code-block::
 

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -89,7 +89,7 @@ builds (e.g., when the ``NDEBUG`` preprocessor macro is defined):
 * ``PORTABLE_ABORT(message)`` prints an error message and aborts the program when compiled in debug mode. This macro **works** in device kernels.
 * ``PORTABLE_THROW(message)`` prints an error message and raises a runtime exception when compiled in debug mode. This macro **does not** work in device kernels.
 * ``PORTABLE_WARN(message)`` prints a warning message if compiled in debug mode. This macro **works** in device kernels.
-* ``PORTABLE_THROW_IFEXCEPT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. As with the above portable, this macro is **disabled in production.** This macro **works** in device kernels.
+* ``PORTABLE_THROW_OR_ABORT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. As with the above portable, this macro is **disabled in production.** This macro **works** in device kernels.
 
 Each of the above macros is **disabled** and becomes a no-op for most builds and only enabled for ``Debug`` builds. However, for each of the above macros there is an equivalent ``PORTABLE_ALWAYS_*`` macro, which **always** functions and is **never** a no-op:
 
@@ -98,7 +98,7 @@ Each of the above macros is **disabled** and becomes a no-op for most builds and
 * ``PORTABLE_ALWAYS_ABORT(message)`` prints an error message and aborts the program. This macro **works** in device kernels.
 * ``PORTABLE_ALWAYS_THROW(message)`` prints an error message and raises a runtime exception. This macro **does not** work in device kernels.
 * ``PORTABLE_ALWAYS_WARN(message)`` prints a warning message. This macro **works** in device kernels.
-* ``PORTABLE_ALWAYS_THROW_IFEXCEPT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. This macro **works** in device kernels.
+* ``PORTABLE_ALWAYS_THROW_OR_ABORT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. This macro **works** in device kernels.
 
 Please note that none of these functions are thread or MPI aware. Iin a parallel program, the same message may be called **many times**. Therefore caution should be used with this machinery and you may wish to hide these macros in if statements, for example,
 

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -96,6 +96,12 @@ Each of the above macros is **disabled** and becomes a no-op for most builds and
 * ``PORTABLE_ALWAYS_WARN(message)`` prints a warning message.
 * ``PORTABLE_ALWAYS_THROW_OR_ABORT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception.
 
+Additionally the macro
+
+* ``PORTABLE_ERROR_MESSAGE(message, output)`` fills an output ``char*`` with a useful error message containing the filename and line number where the macro is called. Note there is no bounds checking so you **must** provide the macro with a sufficiently large ``char*`` array.
+
+The ``message`` parameter in the above macros can be ``char*`` arrays and string literals on device and additionally accepts ``std::string`` and ``std::stringstream`` on host.
+
 Please note that none of these functions are thread or MPI aware. In a parallel program, the same message may be called **many times**. Therefore caution should be used with this machinery and you may wish to hide these macros in if statements, for example,
 
 .. code-block::

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -29,7 +29,7 @@ it defaults to NONE). The above macros then behave as expected. In
 particular, ``PORTABLE_FUNCTION`` and friends resolve to ``__host__
 __device__`` decorators as appropriate.
 
-There are to be two headers in this library, for different use cases.
+There are several headers in this library, for different use cases.
 
 portability.hpp
 ^^^^^^^^^^^^^^^^
@@ -73,7 +73,42 @@ limited. The syntax is:
 where ``Function`` now takes as many indices are required and
 ``reduced`` as arguments.
 
-portable_arrays.hpp
+portable_errors.hpp
+^^^^^^^^^^^^^^^^^^^^
+
+``portable_errors.hpp`` provides error handling that works with
+different portability backends, such as `Kokkos`. We provide several
+useful macros. All the macros in this file will print the file and
+line number where the macro was called, enabling easier debugging.
+
+The following macros are **disabled** automaticaly for production
+builds (e.g., when the ``NDEBUG`` preprocessor macro is defined):
+
+* ``PORTABLE_REQUIRE(condition, message)`` prints an error message and aborts the program (without throwing an exception) if compiled in debug mode and ``condition`` is not satisfied. This macro **works** in device kernels.
+* ``PORTABLE_REQUIRE_THROWS(condition, message)`` raises a runtime exception (annotated with the message) when compiled in debug mode and the condition is not satisfied. This macro **does not** work in device kernels.
+* ``PORTABLE_ABORT(message)`` prints an error message and aborts the program when compiled in debug mode. This macro **works** in device kernels.
+* ``PORTABLE_THROW(message)`` prints an error message and raises a runtime exception when compiled in debug mode. This macro **does not** work in device kernels.
+* ``PORTABLE_WARN(message)`` prints a warning message if compiled in debug mode. This macro **works** in device kernels.
+* ``PORTABLE_THROW_IFEXCEPT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. As with the above portable, this macro is **disabled in production.** This macro **works** in device kernels.
+
+Each of the above macros is **disabled** and becomes a no-op for most builds and only enabled for ``Debug`` builds. However, for each of the above macros there is an equivalent ``PORTABLE_ALWAYS_*`` macro, which **always** functions and is **never** a no-op:
+
+* ``PORTABLE_ALWAYS_REQUIRE(condition, message)`` prints an error message and aborts the program (without throwing an exception) if ``condition`` is not satisfied. This macro **works** in device kernels.
+* ``PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)`` raises a runtime exception (annotated with the message) when the condition is not satisfied. This macro **does not** work in device kernels.
+* ``PORTABLE_ALWAYS_ABORT(message)`` prints an error message and aborts the program. This macro **works** in device kernels.
+* ``PORTABLE_ALWAYS_THROW(message)`` prints an error message and raises a runtime exception. This macro **does not** work in device kernels.
+* ``PORTABLE_ALWAYS_WARN(message)`` prints a warning message. This macro **works** in device kernels.
+* ``PORTABLE_ALWAYS_THROW_IFEXCEPT(message)`` prints an error message and then raises a runtime error if ``PORTABILITY_STRATEGY`` is ``NONE`` and otherwise aborts the program without an exception. This macro **works** in device kernels.
+
+Please note that none of these functions are thread or MPI aware. Iin a parallel program, the same message may be called **many times**. Therefore caution should be used with this machinery and you may wish to hide these macros in if statements, for example,
+
+.. code-block::
+
+  if (rank == 0) PORTABLE_REQUIRE(my_condition, my_message);
+
+as appropriate.
+
+macros_arrays.hpp
 ^^^^^^^^^^^^^^^^^^^
 
 ``portable_arrays.hpp`` provides a wrapper class, ``PortableMDArray``,

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -49,9 +49,9 @@
   PortsOfCall::ErrorChecking::warn(message, __FILE__, __LINE__);
 
 #ifdef PORTABILITY_STRATEGY_NONE
-#define PORTABLE_ALWAYS_THROW_IFEXCEPT(message) PORTABLE_ALWAYS_THROW(message)
+#define PORTABLE_ALWAYS_THROW_OR_ABORT(message) PORTABLE_ALWAYS_THROW(message)
 #else
-#define PORTABLE_ALWAYS_THROW_IFEXCEPT(message) PORTABLE_ALWYAS_ABORT(message)
+#define PORTABLE_ALWAYS_THROW_OR_ABORT(message) PORTABLE_ALWYAS_ABORT(message)
 #endif // PORTABILITY_STRATEGY_NONE
 
 #ifdef NDEBUG
@@ -60,7 +60,7 @@
 #define PORTABLE_ABORT(message) ((void)0)
 #define PORTABLE_THROW(message) ((void)0)
 #define PORTABLE_WARN(message) ((void)0)
-#define PORTABLE_THROW_IFEXCEPT(message) ((void)0)
+#define PORTABLE_THROW_OR_ABORT(message) ((void)0)
 #else
 #define PORTABLE_REQUIRE(condition, message)                                   \
   PORTABLE_ALWAYS_REQUIRE(condition, message)
@@ -69,7 +69,7 @@
 #define PORTABLE_ABORT(message) PORTABLE_ALWAYS_ABORT(message)
 #define PORTABLE_THROW(message) PORTABLE_ALWAYS_THROW(message)
 #define PORTABLE_WARN(message) PORTABLE_ALWAYS_WARN(message)
-#define PORTABLE_THROW_IFEXCEPT(message) PORTABLE_ALWAYS_THROW_IFEXCEPT(message)
+#define PORTABLE_THROW_OR_ABORT(message) PORTABLE_ALWAYS_THROW_OR_ABORT(message)
 #endif // NDEBUG
 
 namespace PortsOfCall {

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -39,6 +39,9 @@
 #define PORTABLE_ALWAYS_WARN(message)                                          \
   PortsOfCall::ErrorChecking::warn(message, __FILE__, __LINE__);
 
+#define PORTABLE_ERROR_MESSAGE(message, output)                                \
+  PortsOfCall::ErrorChecking::error_msg(message, __FILE__, __LINE__, output);
+
 #ifdef PORTABILITY_STRATEGY_NONE
 #define PORTABLE_ALWAYS_THROW_OR_ABORT(message)                                \
   PortsOfCall::ErrorChecking::abort_throws(message, __FILE__, __LINE__);
@@ -81,9 +84,9 @@ namespace impl {
                                                    const char *const message,
                                                    const char *const filename,
                                                    int const linenumber) {
-  printf("### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
-         "%s\n  Line number: %i\n",
-         condition, message, filename, linenumber);
+  std::printf("### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
+              "%s\n  Line number: %i\n",
+              condition, message, filename, linenumber);
   impl::abort(message);
 }
 
@@ -101,8 +104,8 @@ inline void require(const char *const condition,
 [[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message,
                                                  const char *const filename,
                                                  int const linenumber) {
-  printf("### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
-         message, filename, linenumber);
+  std::printf("### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+              message, filename, linenumber);
   impl::abort(message);
 }
 
@@ -143,9 +146,9 @@ inline void require(const char *const condition,
 PORTABLE_INLINE_FUNCTION
 void warn(const char *const message, const char *const filename,
           int const linenumber) {
-  printf("### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "
-         "%i\n",
-         message, filename, linenumber);
+  std::printf("### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "
+              "%i\n",
+              message, filename, linenumber);
 }
 
 inline void warn(std::stringstream const &message, const char *const filename,
@@ -156,6 +159,24 @@ inline void warn(std::stringstream const &message, const char *const filename,
 inline void warn(std::string const &message, const char *const filename,
                  int const linenumber) {
   warn(message.c_str(), filename, linenumber);
+}
+
+PORTABLE_INLINE_FUNCTION
+void error_msg(const char *const input_message, const char *const filename,
+               int const linenumber, char *output_message) {
+  std::sprintf(output_message,
+               "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+               input_message, filename, linenumber);
+}
+
+inline void error_msg(std::stringstream const &input_message, const char *const filename,
+                      int const linenumber, char *output_message) {
+  error_msg(input_message.str().c_str(), filename, linenumber, output_message);
+}
+
+inline void error_msg(std::string const &message, const char *const filename,
+                        int const linenumber) {
+  error_msg(input_message.c_str(), filename, linenumber, output_message);
 }
 
 } // namespace ErrorChecking

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -27,23 +27,25 @@
 // TODO(JMM): Is relative path right here?
 #include "portability.hpp"
 
-#define PORTABLE_ALWAYS_REQUIRE(condition, message)                                      \
-  if (!(condition)) {                                                                    \
-    PortsOfCall::ErrorChecking::require(#condition, message, __FILE__, __LINE__);        \
+#define PORTABLE_ALWAYS_REQUIRE(condition, message)                            \
+  if (!(condition)) {                                                          \
+    PortsOfCall::ErrorChecking::require(#condition, message, __FILE__,         \
+                                        __LINE__);                             \
   }
 
-#define PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)                               \
-  if (!(condition)) {                                                                    \
-    PortsOfCall::ErrorChecking::require_throws(#condition, message, __FILE__, __LINE__); \
+#define PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)                     \
+  if (!(condition)) {                                                          \
+    PortsOfCall::ErrorChecking::require_throws(#condition, message, __FILE__,  \
+                                               __LINE__);                      \
   }
 
-#define PORTABLE_ALWAYS_ABORT(message)                                                   \
+#define PORTABLE_ALWAYS_ABORT(message)                                         \
   PortsOfCall::ErrorChecking::abort(message, __FILE__, __LINE__);
 
-#define PORTABLE_ALWAYS_THROW(message)                                                   \
+#define PORTABLE_ALWAYS_THROW(message)                                         \
   PortsOfCall::ErrorChecking::abort_throws(message, __FILE__, __LINE__);
 
-#define PORTABLE_ALWAYS_WARN(message)                                                    \
+#define PORTABLE_ALWAYS_WARN(message)                                          \
   PortsOfCall::ErrorChecking::warn(message, __FILE__, __LINE__);
 
 #ifdef PORTABILITY_STRATEGY_NONE
@@ -52,17 +54,17 @@
 #define PORTABLE_ALWAYS_THROW_IFEXCEPT(message) PORTABLE_ALWYAS_ABORT(message)
 #endif // PORTABILITY_STRATEGY_NONE
 
-#ifndef NDEBUG
+#fdef NDEBUG
 #define PORTABLE_REQUIRE(condition, message) ((void)0)
 #define PORTABLE_REQUIRE_THROWS(condition, message) ((void)0)
 #define PORTABLE_ABORT(message) ((void)0)
-#define PORTABLE_THROW( message) ((void)0)
+#define PORTABLE_THROW(message) ((void)0)
 #define PORTABLE_WARN(message) ((void)0)
 #define PORTABLE_THROW_IFEXCEPT(message) ((void)0)
 #else
-#define PORTABLE_REQUIRE(condition, message)                                            \
+#define PORTABLE_REQUIRE(condition, message)                                   \
   PORTABLE_ALWAYS_REQUIRE(condition, message)
-#define PORTABLE_REQUIRE_THROWS(condition, message)                                     \
+#define PORTABLE_REQUIRE_THROWS(condition, message)                            \
   PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)
 #define PORTABLE_ABORT(message) PORTABLE_ALWAYS_ABORT(message)
 #define PORTABLE_THROW(message) PORTABLE_ALWAYS_THROW(message)
@@ -73,25 +75,24 @@
 namespace PortsOfCall {
 namespace ErrorChecking {
 namespace impl {
-[[noreturn]]
-KOKKOS_INLINE_FUNCTION
-void abort(const char *const message) {
+[[noreturn]] KOKKOS_INLINE_FUNCTION void abort(const char *const message) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::abort(message);
   // For some versions of Kokkos, Kokkos::abort ends control flow, but
   // is not marked as `[[noreturn]]`, so we need this loop to supress
   // a warning that the function does not return.
-  while (true) {}
+  while (true) {
+  }
 #else
   std::abort();
 #endif // PORTABILITY_STRATEGY_KOKKOS
 }
 } // namespace impl
 
-[[noreturn]]
-KOKKOS_INLINE_FUNCTION
-void require(const char *const condition, const char *const message,
-             const char *const filename, int const linenumber) {
+[[noreturn]] KOKKOS_INLINE_FUNCTION void require(const char *const condition,
+                                                 const char *const message,
+                                                 const char *const filename,
+                                                 int const linenumber) {
   printf("### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
          "%s\n  Line number: %i\n",
          condition, message, filename, linenumber);
@@ -103,12 +104,14 @@ inline void require(const char *const condition, std::string const &message,
   require(condition, message.c_str(), filename, linenumber);
 }
 
-inline void require(const char *const condition, std::stringstream const &message,
+inline void require(const char *const condition,
+                    std::stringstream const &message,
                     const char *const filename, int const linenumber) {
   require(condition, message.str().c_str(), filename, linenumber);
 }
 
-inline void require_throws(const char *const condition, const char *const message,
+inline void require_throws(const char *const condition,
+                           const char *const message,
                            const char *const filename, int const linenumber) {
   std::stringstream msg;
   msg << "### ERROR\n  Condition:   " << condition
@@ -117,36 +120,41 @@ inline void require_throws(const char *const condition, const char *const messag
   throw std::runtime_error(msg.str().c_str());
 }
 
-inline void require_throws(const char *const condition, std::string const &message,
+inline void require_throws(const char *const condition,
+                           std::string const &message,
                            const char *const filename, int const linenumber) {
   require_throws(condition, message.c_str(), filename, linenumber);
 }
 
-inline void require_throws(const char *const condition, std::stringstream const &message,
+inline void require_throws(const char *const condition,
+                           std::stringstream const &message,
                            const char *const filename, int const linenumber) {
   require_throws(condition, message.str().c_str(), filename, linenumber);
 }
 
-[[noreturn]]
-PORTABLE_INLINE_FUNCTION
-void abort(const char *const message, const char *const filename, int const linenumber) {
+[[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message,
+                                                 const char *const filename,
+                                                 int const linenumber) {
   printf("### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
          message, filename, linenumber);
   impl::abort(message);
 }
 
 [[noreturn]] inline void abort(std::stringstream const &message,
-                               const char *const filename, int const linenumber) {
+                               const char *const filename,
+                               int const linenumber) {
   abort(message.str().c_str(), filename, linenumber);
 }
 
 [[noreturn]] inline void abort(std::string const &message,
-                               const char *const filename, int const linenumber) {
+                               const char *const filename,
+                               int const linenumber) {
   abort(message.str().c_str(), filename, linenumber);
 }
 
 [[noreturn]] inline void abort_throws(const char *const message,
-                                      const char *const filename, int const linenumber) {
+                                      const char *const filename,
+                                      int const linenumber) {
   std::stringstream msg;
   msg << "### ERROR\n  Message:     " << message
       << "\n  File:        " << filename << "\n  Line number: " << linenumber
@@ -155,17 +163,20 @@ void abort(const char *const message, const char *const filename, int const line
 }
 
 [[noreturn]] inline void abort_throws(std::string const &message,
-                                      const char *const filename, int const linenumber) {
+                                      const char *const filename,
+                                      int const linenumber) {
   abort_throws(message.c_str(), filename, linenumber);
 }
 
 [[noreturn]] inline void fail_throws(std::stringstream const &message,
-                                     const char *const filename, int const linenumber) {
+                                     const char *const filename,
+                                     int const linenumber) {
   abort_throws(message.str().c_str(), filename, linenumber);
 }
 
 KOKKOS_INLINE_FUNCTION
-void warn(const char *const message, const char *const filename, int const linenumber) {
+void warn(const char *const message, const char *const filename,
+          int const linenumber) {
   printf("### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "
          "%i\n",
          message, filename, linenumber);

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -33,41 +33,29 @@
                                         __LINE__);                             \
   }
 
-#define PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)                     \
-  if (!(condition)) {                                                          \
-    PortsOfCall::ErrorChecking::require_throws(#condition, message, __FILE__,  \
-                                               __LINE__);                      \
-  }
-
 #define PORTABLE_ALWAYS_ABORT(message)                                         \
   PortsOfCall::ErrorChecking::abort(message, __FILE__, __LINE__);
-
-#define PORTABLE_ALWAYS_THROW(message)                                         \
-  PortsOfCall::ErrorChecking::abort_throws(message, __FILE__, __LINE__);
 
 #define PORTABLE_ALWAYS_WARN(message)                                          \
   PortsOfCall::ErrorChecking::warn(message, __FILE__, __LINE__);
 
 #ifdef PORTABILITY_STRATEGY_NONE
-#define PORTABLE_ALWAYS_THROW_OR_ABORT(message) PORTABLE_ALWAYS_THROW(message)
+#define PORTABLE_ALWAYS_THROW_OR_ABORT(message)                                \
+  PortsOfCall::ErrorChecking::abort_throws(message, __FILE__, __LINE__);
 #else
-#define PORTABLE_ALWAYS_THROW_OR_ABORT(message) PORTABLE_ALWYAS_ABORT(message)
+#define PORTABLE_ALWAYS_THROW_OR_ABORT(message)                                \
+  PortsOfCall::ErrorChecking::abort(message, __FILE__, __LINE__);
 #endif // PORTABILITY_STRATEGY_NONE
 
 #ifdef NDEBUG
 #define PORTABLE_REQUIRE(condition, message) ((void)0)
-#define PORTABLE_REQUIRE_THROWS(condition, message) ((void)0)
 #define PORTABLE_ABORT(message) ((void)0)
-#define PORTABLE_THROW(message) ((void)0)
 #define PORTABLE_WARN(message) ((void)0)
 #define PORTABLE_THROW_OR_ABORT(message) ((void)0)
 #else
 #define PORTABLE_REQUIRE(condition, message)                                   \
   PORTABLE_ALWAYS_REQUIRE(condition, message)
-#define PORTABLE_REQUIRE_THROWS(condition, message)                            \
-  PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)
 #define PORTABLE_ABORT(message) PORTABLE_ALWAYS_ABORT(message)
-#define PORTABLE_THROW(message) PORTABLE_ALWAYS_THROW(message)
 #define PORTABLE_WARN(message) PORTABLE_ALWAYS_WARN(message)
 #define PORTABLE_THROW_OR_ABORT(message) PORTABLE_ALWAYS_THROW_OR_ABORT(message)
 #endif // NDEBUG
@@ -110,28 +98,6 @@ inline void require(const char *const condition,
   require(condition, message.str().c_str(), filename, linenumber);
 }
 
-inline void require_throws(const char *const condition,
-                           const char *const message,
-                           const char *const filename, int const linenumber) {
-  std::stringstream msg;
-  msg << "### ERROR\n  Condition:   " << condition
-      << "\n  Message:     " << message << "\n  File:        " << filename
-      << "\n  Line number: " << linenumber << std::endl;
-  throw std::runtime_error(msg.str().c_str());
-}
-
-inline void require_throws(const char *const condition,
-                           std::string const &message,
-                           const char *const filename, int const linenumber) {
-  require_throws(condition, message.c_str(), filename, linenumber);
-}
-
-inline void require_throws(const char *const condition,
-                           std::stringstream const &message,
-                           const char *const filename, int const linenumber) {
-  require_throws(condition, message.str().c_str(), filename, linenumber);
-}
-
 [[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message,
                                                  const char *const filename,
                                                  int const linenumber) {
@@ -168,7 +134,7 @@ inline void require_throws(const char *const condition,
   abort_throws(message.c_str(), filename, linenumber);
 }
 
-[[noreturn]] inline void fail_throws(std::stringstream const &message,
+[[noreturn]] inline void abort_throws(std::stringstream const &message,
                                      const char *const filename,
                                      int const linenumber) {
   abort_throws(message.str().c_str(), filename, linenumber);

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -90,9 +90,9 @@ namespace ErrorChecking {
 namespace impl {
 // Abort with an error message. The abort function depends on
 // portability backend.
-[[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message) {
+[[noreturn]] PORTABLE_INLINE_FUNCTION void abort() {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  Kokkos::abort(message);
+  Kokkos::abort("");
   // For some versions of Kokkos, Kokkos::abort ends control flow, but
   // is not marked as `[[noreturn]]`, so we need this loop to supress
   // a warning that the function does not return.
@@ -111,10 +111,12 @@ namespace impl {
                                                    const char *const message,
                                                    const char *const filename,
                                                    int const linenumber) {
-  std::printf("### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
-              "%s\n  Line number: %i\n",
-              condition, message, filename, linenumber);
-  impl::abort(message);
+  std::fprintf(
+      stderr,
+      "### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
+      "%s\n  Line number: %i\n",
+      condition, message, filename, linenumber);
+  impl::abort();
 }
 inline void require(const char *const condition, std::string const &message,
                     const char *const filename, int const linenumber) {
@@ -130,9 +132,11 @@ inline void require(const char *const condition,
 [[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message,
                                                  const char *const filename,
                                                  int const linenumber) {
-  std::printf("### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
-              message, filename, linenumber);
-  impl::abort(message);
+  std::fprintf(
+      stderr,
+      "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+      message, filename, linenumber);
+  impl::abort();
 }
 [[noreturn]] inline void abort(std::stringstream const &message,
                                const char *const filename,
@@ -162,8 +166,8 @@ inline void require(const char *const condition,
   abort_throws(message.c_str(), filename, linenumber);
 }
 [[noreturn]] inline void abort_throws(std::stringstream const &message,
-                                     const char *const filename,
-                                     int const linenumber) {
+                                      const char *const filename,
+                                      int const linenumber) {
   abort_throws(message.str().c_str(), filename, linenumber);
 }
 
@@ -172,9 +176,11 @@ inline void require(const char *const condition,
 PORTABLE_INLINE_FUNCTION
 void warn(const char *const message, const char *const filename,
           int const linenumber) {
-  std::printf("### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "
-              "%i\n",
-              message, filename, linenumber);
+  std::fprintf(
+      stderr,
+      "### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "
+      "%i\n",
+      message, filename, linenumber);
 }
 inline void warn(std::stringstream const &message, const char *const filename,
                  int const linenumber) {
@@ -190,12 +196,14 @@ inline void warn(std::string const &message, const char *const filename,
 PORTABLE_INLINE_FUNCTION
 void error_msg(const char *const input_message, const char *const filename,
                int const linenumber, char *output_message) {
-  std::sprintf(output_message,
-               "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
-               input_message, filename, linenumber);
+  std::sprintf(
+      output_message,
+      "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+      input_message, filename, linenumber);
 }
-inline void error_msg(std::stringstream const &input_message, const char *const filename,
-                      int const linenumber, char *output_message) {
+inline void error_msg(std::stringstream const &input_message,
+                      const char *const filename, int const linenumber,
+                      char *output_message) {
   error_msg(input_message.str().c_str(), filename, linenumber, output_message);
 }
 inline void error_msg(std::string const &message, const char *const filename,

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -27,21 +27,38 @@
 // TODO(JMM): Is relative path right here?
 #include "portability.hpp"
 
+// Use these macros for error handling. A macro is required, as
+// opposed to a function, so that the file name and line number can be
+// pulled from the call site.
+
+// Messages passed in can be C strings, C++ strings, or stringstreams
+
+// Use this as an assert with an error message. This assert is *not*
+// disabled when compiling for production.
 #define PORTABLE_ALWAYS_REQUIRE(condition, message)                            \
   if (!(condition)) {                                                          \
     PortsOfCall::ErrorChecking::require(#condition, message, __FILE__,         \
                                         __LINE__);                             \
   }
 
+// Use this to abort the program with an error message with file and
+// line number.
 #define PORTABLE_ALWAYS_ABORT(message)                                         \
   PortsOfCall::ErrorChecking::abort(message, __FILE__, __LINE__);
 
+// Prints a warning with file and line number.
 #define PORTABLE_ALWAYS_WARN(message)                                          \
   PortsOfCall::ErrorChecking::warn(message, __FILE__, __LINE__);
 
+// Fills a char* array output with an error message
+// with file name and line number. Note there is no bounds checking
+// so make sure you allocate enough memory.
 #define PORTABLE_ERROR_MESSAGE(message, output)                                \
   PortsOfCall::ErrorChecking::error_msg(message, __FILE__, __LINE__, output);
 
+// Aborts the program with an error message with file and line number.
+// if PORTABILITY_STRATEGY_NONE is enabled, then this throws a C++
+// exception. Otherwise exceptions are not used.
 #ifdef PORTABILITY_STRATEGY_NONE
 #define PORTABLE_ALWAYS_THROW_OR_ABORT(message)                                \
   PortsOfCall::ErrorChecking::abort_throws(message, __FILE__, __LINE__);
@@ -50,6 +67,7 @@
   PortsOfCall::ErrorChecking::abort(message, __FILE__, __LINE__);
 #endif // PORTABILITY_STRATEGY_NONE
 
+// Same as the above, but disabled when compiled in release mode.
 #ifdef NDEBUG
 #define PORTABLE_REQUIRE(condition, message) ((void)0)
 #define PORTABLE_ABORT(message) ((void)0)
@@ -63,9 +81,15 @@
 #define PORTABLE_THROW_OR_ABORT(message) PORTABLE_ALWAYS_THROW_OR_ABORT(message)
 #endif // NDEBUG
 
+// Below are the underlying type-safe functions called by the
+// macros. The functions are not to be called by downstream users, as
+// they don't know file and line numbers. They simply enable type
+// checking for the above macros,
 namespace PortsOfCall {
 namespace ErrorChecking {
 namespace impl {
+// Abort with an error message. The abort function depends on
+// portability backend.
 [[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::abort(message);
@@ -80,6 +104,9 @@ namespace impl {
 }
 } // namespace impl
 
+// Prints an error message describing the failed condition in an
+// assert (the assertion is applied above in the macro) with file name
+// and line number. Then aborts.
 [[noreturn]] PORTABLE_INLINE_FUNCTION void require(const char *const condition,
                                                    const char *const message,
                                                    const char *const filename,
@@ -89,18 +116,17 @@ namespace impl {
               condition, message, filename, linenumber);
   impl::abort(message);
 }
-
 inline void require(const char *const condition, std::string const &message,
                     const char *const filename, int const linenumber) {
   require(condition, message.c_str(), filename, linenumber);
 }
-
 inline void require(const char *const condition,
                     std::stringstream const &message,
                     const char *const filename, int const linenumber) {
   require(condition, message.str().c_str(), filename, linenumber);
 }
 
+// Prints an error message with file name and line number and then aborts.
 [[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message,
                                                  const char *const filename,
                                                  int const linenumber) {
@@ -108,19 +134,19 @@ inline void require(const char *const condition,
               message, filename, linenumber);
   impl::abort(message);
 }
-
 [[noreturn]] inline void abort(std::stringstream const &message,
                                const char *const filename,
                                int const linenumber) {
   abort(message.str().c_str(), filename, linenumber);
 }
-
 [[noreturn]] inline void abort(std::string const &message,
                                const char *const filename,
                                int const linenumber) {
   abort(message.c_str(), filename, linenumber);
 }
 
+// Prints an error message with file name and line number and then
+// throws an exception.
 [[noreturn]] inline void abort_throws(const char *const message,
                                       const char *const filename,
                                       int const linenumber) {
@@ -130,19 +156,19 @@ inline void require(const char *const condition,
       << std::endl;
   throw std::runtime_error(msg.str().c_str());
 }
-
 [[noreturn]] inline void abort_throws(std::string const &message,
                                       const char *const filename,
                                       int const linenumber) {
   abort_throws(message.c_str(), filename, linenumber);
 }
-
 [[noreturn]] inline void abort_throws(std::stringstream const &message,
                                      const char *const filename,
                                      int const linenumber) {
   abort_throws(message.str().c_str(), filename, linenumber);
 }
 
+// Prints an warning message with file name and line number and then
+// program continues.
 PORTABLE_INLINE_FUNCTION
 void warn(const char *const message, const char *const filename,
           int const linenumber) {
@@ -150,17 +176,17 @@ void warn(const char *const message, const char *const filename,
               "%i\n",
               message, filename, linenumber);
 }
-
 inline void warn(std::stringstream const &message, const char *const filename,
                  int const linenumber) {
   warn(message.str().c_str(), filename, linenumber);
 }
-
 inline void warn(std::string const &message, const char *const filename,
                  int const linenumber) {
   warn(message.c_str(), filename, linenumber);
 }
 
+// Fills the output_message char* array with an error message with
+// filename and line number. Beware! No bounds checking!
 PORTABLE_INLINE_FUNCTION
 void error_msg(const char *const input_message, const char *const filename,
                int const linenumber, char *output_message) {
@@ -168,14 +194,12 @@ void error_msg(const char *const input_message, const char *const filename,
                "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
                input_message, filename, linenumber);
 }
-
 inline void error_msg(std::stringstream const &input_message, const char *const filename,
                       int const linenumber, char *output_message) {
   error_msg(input_message.str().c_str(), filename, linenumber, output_message);
 }
-
 inline void error_msg(std::string const &message, const char *const filename,
-                        int const linenumber) {
+                      int const linenumber, char *output_message) {
   error_msg(input_message.c_str(), filename, linenumber, output_message);
 }
 

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -118,7 +118,7 @@ inline void require(const char *const condition,
 [[noreturn]] inline void abort(std::string const &message,
                                const char *const filename,
                                int const linenumber) {
-  abort(message.str().c_str(), filename, linenumber);
+  abort(message.c_str(), filename, linenumber);
 }
 
 [[noreturn]] inline void abort_throws(const char *const message,

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -54,7 +54,7 @@
 #define PORTABLE_ALWAYS_THROW_IFEXCEPT(message) PORTABLE_ALWYAS_ABORT(message)
 #endif // PORTABILITY_STRATEGY_NONE
 
-#fdef NDEBUG
+#ifdef NDEBUG
 #define PORTABLE_REQUIRE(condition, message) ((void)0)
 #define PORTABLE_REQUIRE_THROWS(condition, message) ((void)0)
 #define PORTABLE_ABORT(message) ((void)0)

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -1,0 +1,187 @@
+#ifndef _PORTS_OF_CALL_PORTABLE_ERRORS_HPP_
+#define _PORTS_OF_CALL_PORTABLE_ERRORS_HPP_
+
+// ========================================================================================
+// © (or copyright) 2023. Triad National Security, LLC. All rights
+// reserved.  This program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which is
+// operated by Triad National Security, LLC for the U.S.  Department of
+// Energy/National Nuclear Security Administration. All rights in the
+// program are reserved by Triad National Security, LLC, and the
+// U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others acting
+// on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute
+// copies to the public, perform publicly and display publicly, and to
+// permit others to do so.
+// ========================================================================================
+
+// C++ headers
+#include <iostream>
+#include <stdexcept>
+
+// C headers
+#include <cstdio>
+#include <cstdlib>
+
+// TODO(JMM): Is relative path right here?
+#include "portability.hpp"
+
+#define PORTABLE_ALWAYS_REQUIRE(condition, message)                                      \
+  if (!(condition)) {                                                                    \
+    PortsOfCall::ErrorChecking::require(#condition, message, __FILE__, __LINE__);        \
+  }
+
+#define PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)                               \
+  if (!(condition)) {                                                                    \
+    PortsOfCall::ErrorChecking::require_throws(#condition, message, __FILE__, __LINE__); \
+  }
+
+#define PORTABLE_ALWAYS_ABORT(message)                                                   \
+  PortsOfCall::ErrorChecking::abort(message, __FILE__, __LINE__);
+
+#define PORTABLE_ALWAYS_THROW(message)                                                   \
+  PortsOfCall::ErrorChecking::abort_throws(message, __FILE__, __LINE__);
+
+#define PORTABLE_ALWAYS_WARN(message)                                                    \
+  PortsOfCall::ErrorChecking::warn(message, __FILE__, __LINE__);
+
+#ifdef PORTABILITY_STRATEGY_NONE
+#define PORTABLE_ALWAYS_THROW_IFEXCEPT(message) PORTABLE_ALWAYS_THROW(message)
+#else
+#define PORTABLE_ALWAYS_THROW_IFEXCEPT(message) PORTABLE_ALWYAS_ABORT(message)
+#endif // PORTABILITY_STRATEGY_NONE
+
+#ifndef NDEBUG
+#define PORTABLE_REQUIRE(condition, message) ((void)0)
+#define PORTABLE_REQUIRE_THROWS(condition, message) ((void)0)
+#define PORTABLE_ABORT(message) ((void)0)
+#define PORTABLE_THROW( message) ((void)0)
+#define PORTABLE_WARN(message) ((void)0)
+#define PORTABLE_THROW_IFEXCEPT(message) ((void)0)
+#else
+#define PORTABLE_REQUIRE(condition, message)                                            \
+  PORTABLE_ALWAYS_REQUIRE(condition, message)
+#define PORTABLE_REQUIRE_THROWS(condition, message)                                     \
+  PORTABLE_ALWAYS_REQUIRE_THROWS(condition, message)
+#define PORTABLE_ABORT(message) PORTABLE_ALWAYS_ABORT(message)
+#define PORTABLE_THROW(message) PORTABLE_ALWAYS_THROW(message)
+#define PORTABLE_WARN(message) PORTABLE_ALWAYS_WARN(message)
+#define PORTABLE_THROW_IFEXCEPT(message) PORTABLE_ALWAYS_THROW_IFEXCEPT(message)
+#endif // NDEBUG
+
+namespace PortsOfCall {
+namespace ErrorChecking {
+namespace impl {
+[[noreturn]]
+KOKKOS_INLINE_FUNCTION
+void abort(const char *const message) {
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::abort(message);
+  // For some versions of Kokkos, Kokkos::abort ends control flow, but
+  // is not marked as `[[noreturn]]`, so we need this loop to supress
+  // a warning that the function does not return.
+  while (true) {}
+#else
+  std::abort();
+#endif // PORTABILITY_STRATEGY_KOKKOS
+}
+} // namespace impl
+
+[[noreturn]]
+KOKKOS_INLINE_FUNCTION
+void require(const char *const condition, const char *const message,
+             const char *const filename, int const linenumber) {
+  printf("### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
+         "%s\n  Line number: %i\n",
+         condition, message, filename, linenumber);
+  impl::abort(message);
+}
+
+inline void require(const char *const condition, std::string const &message,
+                    const char *const filename, int const linenumber) {
+  require(condition, message.c_str(), filename, linenumber);
+}
+
+inline void require(const char *const condition, std::stringstream const &message,
+                    const char *const filename, int const linenumber) {
+  require(condition, message.str().c_str(), filename, linenumber);
+}
+
+inline void require_throws(const char *const condition, const char *const message,
+                           const char *const filename, int const linenumber) {
+  std::stringstream msg;
+  msg << "### ERROR\n  Condition:   " << condition
+      << "\n  Message:     " << message << "\n  File:        " << filename
+      << "\n  Line number: " << linenumber << std::endl;
+  throw std::runtime_error(msg.str().c_str());
+}
+
+inline void require_throws(const char *const condition, std::string const &message,
+                           const char *const filename, int const linenumber) {
+  require_throws(condition, message.c_str(), filename, linenumber);
+}
+
+inline void require_throws(const char *const condition, std::stringstream const &message,
+                           const char *const filename, int const linenumber) {
+  require_throws(condition, message.str().c_str(), filename, linenumber);
+}
+
+[[noreturn]]
+PORTABLE_INLINE_FUNCTION
+void abort(const char *const message, const char *const filename, int const linenumber) {
+  printf("### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+         message, filename, linenumber);
+  impl::abort(message);
+}
+
+[[noreturn]] inline void abort(std::stringstream const &message,
+                               const char *const filename, int const linenumber) {
+  abort(message.str().c_str(), filename, linenumber);
+}
+
+[[noreturn]] inline void abort(std::string const &message,
+                               const char *const filename, int const linenumber) {
+  abort(message.str().c_str(), filename, linenumber);
+}
+
+[[noreturn]] inline void abort_throws(const char *const message,
+                                      const char *const filename, int const linenumber) {
+  std::stringstream msg;
+  msg << "### ERROR\n  Message:     " << message
+      << "\n  File:        " << filename << "\n  Line number: " << linenumber
+      << std::endl;
+  throw std::runtime_error(msg.str().c_str());
+}
+
+[[noreturn]] inline void abort_throws(std::string const &message,
+                                      const char *const filename, int const linenumber) {
+  abort_throws(message.c_str(), filename, linenumber);
+}
+
+[[noreturn]] inline void fail_throws(std::stringstream const &message,
+                                     const char *const filename, int const linenumber) {
+  abort_throws(message.str().c_str(), filename, linenumber);
+}
+
+KOKKOS_INLINE_FUNCTION
+void warn(const char *const message, const char *const filename, int const linenumber) {
+  printf("### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "
+         "%i\n",
+         message, filename, linenumber);
+}
+
+inline void warn(std::stringstream const &message, const char *const filename,
+                 int const linenumber) {
+  warn(message.str().c_str(), filename, linenumber);
+}
+
+inline void warn(std::string const &message, const char *const filename,
+                 int const linenumber) {
+  warn(message.c_str(), filename, linenumber);
+}
+
+} // namespace ErrorChecking
+} // namespace PortsOfCall
+
+#endif // _PORTS_OF_CALL_PORTABLE_ERRORS_HPP_

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -75,7 +75,7 @@
 namespace PortsOfCall {
 namespace ErrorChecking {
 namespace impl {
-[[noreturn]] KOKKOS_INLINE_FUNCTION void abort(const char *const message) {
+[[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::abort(message);
   // For some versions of Kokkos, Kokkos::abort ends control flow, but
@@ -89,10 +89,10 @@ namespace impl {
 }
 } // namespace impl
 
-[[noreturn]] KOKKOS_INLINE_FUNCTION void require(const char *const condition,
-                                                 const char *const message,
-                                                 const char *const filename,
-                                                 int const linenumber) {
+[[noreturn]] PORTABLE_INLINE_FUNCTION void require(const char *const condition,
+                                                   const char *const message,
+                                                   const char *const filename,
+                                                   int const linenumber) {
   printf("### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
          "%s\n  Line number: %i\n",
          condition, message, filename, linenumber);
@@ -174,7 +174,7 @@ inline void require_throws(const char *const condition,
   abort_throws(message.str().c_str(), filename, linenumber);
 }
 
-KOKKOS_INLINE_FUNCTION
+PORTABLE_INLINE_FUNCTION
 void warn(const char *const message, const char *const filename,
           int const linenumber) {
   printf("### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In [the Vinet PR](https://github.com/lanl/singularity-eos/pull/202) by @aematts in singularity-eos some issues with the current error handling in singularity-eos were noted. I believe a performance-portable error handling treatment should be developed and properly lives in `ports-of-call`. I introduce it here. In particular, I define several flavors of macro:
- `PORTABLE_REQUIRE` which is an assert statement with file and line numbers
- `PORTABLE_REQUIRE_THROWS` as above but throws an exception
- `PORTABLE_ABORT` which is a fail statement with file and line numbers, resolves to backend aborts appropriate
- `PORTABLE_THROW` resolves to throwing an exception
- `PORTABLE_THROW_IFEXCEPT` resolves to either an exception or an abort depending on portability strategy
- `PORTABLE_WARN` which is a warning with file and line numbers 

All the above are no-ops by default, but are enabled for debug builds. I also provide `PORTABLE_ALWAYS_*` macros which always work.

The idea here is by default error handling should be silent unless you're debugging. But if the developer knows they want a message or a failure, they can insert one. For the Vinet PR, initialization errors should probably be handled with `PORTABLE_THROW_IFEXCEPT` for example.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
