### PR TITLE
Change behavior of `require` to match documentation

### DIFF
--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -111,7 +111,7 @@ namespace impl {
                                                    const char *const message,
                                                    const char *const filename,
                                                    int const linenumber) {
-  if (condition_bool) {
+  if (!condition_bool) {
     std::printf(
         "### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
         "%s\n  Line number: %i\n",


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
If we 'require' something, then the _failed_ condition should trigger the error message, not the success. This small change brings the code in line with the documentation and my understanding of the intent of the `REQUIRE` macros.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [x] Install test passes.
- [x] Docs build.
- N/A If preparing for a new release, update the version in cmake.
