### PR TITLE
Remove [[noreturn]] from 'require' since it should return under most circumstances

### DIFF
--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -107,10 +107,10 @@ namespace impl {
 // assert (the assertion is applied above in the macro) with file name
 // and line number. Then aborts.
 PORTABLE_INLINE_FUNCTION void require(bool condition_bool,
-                                                   const char *const condition,
-                                                   const char *const message,
-                                                   const char *const filename,
-                                                   int const linenumber) {
+                                      const char *const condition,
+                                      const char *const message,
+                                      const char *const filename,
+                                      int const linenumber) {
   if (!condition_bool) {
     std::printf(
         "### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -106,7 +106,7 @@ namespace impl {
 // Prints an error message describing the failed condition in an
 // assert (the assertion is applied above in the macro) with file name
 // and line number. Then aborts.
-[[noreturn]] PORTABLE_INLINE_FUNCTION void require(bool condition_bool,
+PORTABLE_INLINE_FUNCTION void require(bool condition_bool,
                                                    const char *const condition,
                                                    const char *const message,
                                                    const char *const filename,


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The `require()` function should usually _not_ return since we would hope the condition is `false`. The `[[noreturn]]` decorator applied to a returning function is undefined behavior. With gcc 10, it looks like the compiler uses `[[noreturn]]` to just give up on keeping track of the stack pointer which leads to a segfault.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [x] Install test passes.
- [x] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
