### PR TITLE
Add core for build tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ target_compile_features(${POCLIB}
 # ----------------------------------------
 if(PORTS_OF_CALL_BUILD_TESTING)
   message(STATUS "Configuring tests")
+  enable_testing()
   add_subdirectory(test)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     "Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
 endif()
 
+include(CTest) # brings in option `BUILD_TESTING`
+
+option (PORTS_OF_CALL_TEST_USE_KOKKOS "Use kokkos offloading for testing")
 
 # CONFIGURATION LOGIC
 # ----------------------------------------
@@ -62,6 +65,13 @@ target_compile_features(${POCLIB}
   INTERFACE
     cxx_std_14
 )
+
+# TESTING
+# ----------------------------------------
+if(BUILD_TESTING)
+  message(STATUS "Configuring tests")
+  add_subdirectory(test)
+endif()
 
 # INSTALL & EXPORT
 # ----------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     "Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
 endif()
 
-include(CTest) # brings in option `BUILD_TESTING`
-
-option (PORTS_OF_CALL_TEST_USE_KOKKOS "Use kokkos offloading for testing")
+option (PORTS_OF_CALL_BUILD_TESTING "Test the current installation")
 
 # CONFIGURATION LOGIC
 # ----------------------------------------
@@ -68,7 +66,7 @@ target_compile_features(${POCLIB}
 
 # TESTING
 # ----------------------------------------
-if(BUILD_TESTING)
+if(PORTS_OF_CALL_BUILD_TESTING)
   message(STATUS "Configuring tests")
   add_subdirectory(test)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ if (PORTS_OF_CALL_TEST_USE_KOKKOS)
   target_compile_definitions(portsofcall_iface INTERFACE PORTABILITY_STRATEGY_KOKKOS)
 endif()
 
+target_link_libraries(portsofcall_iface INTERFACE Catch2::Catch2)
 # add unit tests
 add_executable(test_portsofcall test_portsofcall.cpp)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,6 @@
 # prepare derivative works, distribute copies to the public, perform
 # publicly and display publicly, and to permit others to do so.
 
-
 find_package(Catch2 REQUIRED)
 
 # this interface target is to collect

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,13 +16,14 @@ find_package(Catch2 REQUIRED)
 # this interface target is to collect
 # compile/link options for the test
 add_library(portsofcall_iface INTERFACE)
-# instructions for local content
-# https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_SOURCE_DIR_%3CuppercaseName%3E
-# TLDR: set FETCHCONTENT_SOURCE_DIR_KOKKOS=path/to/local/checkout
-if (PORTS_OF_CALL_TEST_USE_KOKKOS)
-  find_package(Kokkos REQUIRED)
+if (PORTABILITY_STRATEGY_KOKKOS)
+  if(NOT TARGET Kokkos::kokkos)
+    find_package(Kokkos REQUIRED)
+  endif()
+
   target_link_libraries(portsofcall_iface INTERFACE Kokkos::kokkos)
-  target_compile_definitions(portsofcall_iface INTERFACE PORTABILITY_STRATEGY_KOKKOS)
+  # this comes with ports-of-call target
+  #target_compile_definitions(portsofcall_iface INTERFACE PORTABILITY_STRATEGY_KOKKOS)
 endif()
 
 target_link_libraries(portsofcall_iface INTERFACE Catch2::Catch2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,39 @@
+# © 2021. Triad National Security, LLC. All rights reserved.  This
+# program was produced under U.S. Government contract 89233218CNA000001
+# for Los Alamos National Laboratory (LANL), which is operated by Triad
+# National Security, LLC for the U.S.  Department of Energy/National
+# Nuclear Security Administration. All rights in the program are
+# reserved by Triad National Security, LLC, and the U.S. Department of
+# Energy/National Nuclear Security Administration. The Government is
+# granted for itself and others acting on its behalf a nonexclusive,
+# paid-up, irrevocable worldwide license in this material to reproduce,
+# prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
+
+
+find_package(Catch2 REQUIRED)
+
+# this interface target is to collect
+# compile/link options for the test
+add_library(portsofcall_iface INTERFACE)
+# instructions for local content
+# https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_SOURCE_DIR_%3CuppercaseName%3E
+# TLDR: set FETCHCONTENT_SOURCE_DIR_KOKKOS=path/to/local/checkout
+if (PORTS_OF_CALL_TEST_USE_KOKKOS)
+  find_package(Kokkos REQUIRED)
+  target_link_libraries(portsofcall_iface INTERFACE Kokkos::kokkos)
+  target_compile_definitions(portsofcall_iface INTERFACE PORTABILITY_STRATEGY_KOKKOS)
+endif()
+
+# add unit tests
+add_executable(test_portsofcall test_portsofcall.cpp)
+
+target_link_libraries(test_portsofcall
+  PRIVATE
+    ports-of-call::ports-of-call
+    portsofcall_iface
+)
+
+include(Catch)
+catch_discover_tests(test_portsofcall)
+

--- a/test/test_portsofcall.cpp
+++ b/test/test_portsofcall.cpp
@@ -1,0 +1,78 @@
+// © (or copyright) 2019-2021. Triad National Security, LLC. All rights
+// reserved.  This program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which is
+// operated by Triad National Security, LLC for the U.S.  Department of
+// Energy/National Nuclear Security Administration. All rights in the
+// program are reserved by Triad National Security, LLC, and the
+// U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others acting
+// on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute
+// copies to the public, perform publicly and display publicly, and to
+// permit others to do so.
+
+#include <ports-of-call/portability.hpp>
+#include <ports-of-call/portable_arrays.hpp>
+
+#define CATCH_CONFIG_RUNNER
+#include "catch2/catch.hpp"
+
+// this test is lifted directly from `spiner`;
+// and there appears to be a significant amount of
+// ports-of-call testing done there.
+TEST_CASE("PortableMDArrays can be allocated from a pointer",
+          "[PortableMDArray]") {
+  constexpr int N = 2;
+  constexpr int M = 3;
+  std::vector<int> data(N * M);
+  PortableMDArray<int> a;
+  int tot = 0;
+  for (int i = 0; i < N * M; i++) {
+    data[i] = tot;
+    tot++;
+  }
+  a.NewPortableMDArray(data.data(), M, N);
+
+  SECTION("Shape should be NxM") {
+    REQUIRE(a.GetDim1() == N);
+    REQUIRE(a.GetDim2() == M);
+  }
+
+  SECTION("Stride is as set by initialized pointer") {
+    int tot = 0;
+    for (int j = 0; j < M; j++) {
+      for (int i = 0; i < N; i++) {
+        REQUIRE(a(j, i) == tot);
+        tot++;
+      }
+    }
+  }
+
+  SECTION("Identical slices of the same data should compare equal") {
+    PortableMDArray<int> aslc1, aslc2;
+    aslc1.InitWithShallowSlice(a, 1, 0, 2);
+    aslc2.InitWithShallowSlice(a, 1, 0, 2);
+    REQUIRE(aslc1 == aslc2);
+  }
+
+}
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+
+SCENARIO("Kokkos functionality","sometest") {
+
+}
+#endif
+
+int main(int argc, char *argv[]) {
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::initialize();
+#endif
+  int result;
+  { result = Catch::Session().run(argc, argv); }
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::finalize();
+#endif
+  return result;
+}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Currently the only test in `ports-of-call` is the install test. This PR does a minimal build configuration for inline tests.

I have included a test from `spiner` that tests `PortableMDArray`, but that is just so there is something to test. It appears there are several tests in `spiner` that should properly be in `ports-of-call`.

New CMake options:

- `-DBUILD_TESTING=[ON/OFF]` for triggering the build of the test exe(s)
- `-DPORTS_OF_CALL_TEST_KOKKOS=[ON/OFF]` for configuring for testing with `Kokkos`

### Dependencies

I'm taking a "less-is-more" approach here; if you want to test, you need `Catch2` available - diddo with `Kokkos`. Further, I've deliberately left *out* an option for Kokkos CUDA; If you want that, then install Kokkos with CUDA enabled.

### CI ?

Should the git[hub/lab] CI begin running these tests? Or should that be a separate PR?

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
