### PR TITLE
Draft: Add portable query for exec space

### DIFF
--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -83,6 +83,14 @@ with `to` being the target location, from being the source location, and size_by
 the size of the transfer in bytes. This has implemenatations for kokkos and none 
 portability strategies.
 
+It may be useful to query the execution space, for example to know where memory needs to be copied.
+To this end, a compile-time constant boolean can be queried:
+
+.. cpp:var:: PortsOfCall::EXECUTION_IS_HOST
+
+which is `true` if the host execution space can trivially access device memory space. For example,
+for `PORTABILITY_STRATEGY_CUDA`, `PortsOfCall::EXECUTION_IS_HOST == false`.
+
 portable_errors.hpp
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -91,6 +91,18 @@ typedef float Real;
 typedef double Real;
 #endif
 
+bool portableExecIsHost()
+{
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  // check if default exec space is the same as the host exec space
+  return std::is_same<Kokkos::DefaultExecutionSpace,Kokkos::HostSpace::execution_space>::value;
+#elif PORTABILITY_STRATEGY_CUDA
+  return false;
+#else
+  return true;
+#endif
+}
+
 template <typename T>
 void portableCopyToDevice(T * const to, T const * const from, size_t const size_bytes) {
   auto const length = size_bytes / sizeof(T);

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -91,15 +91,17 @@ typedef float Real;
 typedef double Real;
 #endif
 
+namespace PortsOfCall{
 // compile-time constant to check if execution of memory space
 // will be done on the host or is offloaded
 #if defined(PORTABILITY_STRATEGY_KOKKOS)
-inline constexpr bool execution_is_host{Kokkos::SpaceAccessibility<Kokkos::DefaultExecutionSpace::memory_space,Kokkos::HostSpace>::accessible};
+inline constexpr bool EXECUTION_IS_HOST{Kokkos::SpaceAccessibility<Kokkos::DefaultExecutionSpace::memory_space,Kokkos::HostSpace>::accessible};
 #elif defined(PORTABILITY_STRATEGY_CUDA)
-inline constexpr bool execution_is_host{false};
+inline constexpr bool EXECUTION_IS_HOST{false};
 #else
-inline constexpr bool execution_is_host{true};
+inline constexpr bool EXECUTION_IS_HOST{true};
 #endif
+} // PortsOfCall
 
 template <typename T>
 void portableCopyToDevice(T * const to, T const * const from, size_t const size_bytes) {

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -93,10 +93,10 @@ typedef double Real;
 
 bool portableExecIsHost()
 {
-#ifdef PORTABILITY_STRATEGY_KOKKOS
+#if defined(PORTABILITY_STRATEGY_KOKKOS)
   // check if default exec space is the same as the host exec space
   return std::is_same<Kokkos::DefaultExecutionSpace,Kokkos::HostSpace::execution_space>::value;
-#elif PORTABILITY_STRATEGY_CUDA
+#elif defined(PORTABILITY_STRATEGY_CUDA)
   return false;
 #else
   return true;

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -91,17 +91,15 @@ typedef float Real;
 typedef double Real;
 #endif
 
-bool portableExecIsHost()
-{
+// compile-time constant to check if execution of memory space
+// will be done on the host or is offloaded
 #if defined(PORTABILITY_STRATEGY_KOKKOS)
-  // check if default exec space is the same as the host exec space
-  return std::is_same<Kokkos::DefaultExecutionSpace,Kokkos::HostSpace::execution_space>::value;
+inline constexpr bool execution_is_host{Kokkos::SpaceAccessibility<Kokkos::DefaultExecutionSpace::memory_space,Kokkos::HostSpace>::accessible};
 #elif defined(PORTABILITY_STRATEGY_CUDA)
-  return false;
+inline constexpr bool execution_is_host{false};
 #else
-  return true;
+inline constexpr bool execution_is_host{true};
 #endif
-}
 
 template <typename T>
 void portableCopyToDevice(T * const to, T const * const from, size_t const size_bytes) {

--- a/test/test_portsofcall.cpp
+++ b/test/test_portsofcall.cpp
@@ -18,10 +18,10 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch2/catch.hpp"
 
-TEST_CASE("execution_is_host is set correctly", 
-    "[portibility flags]") {
+TEST_CASE("EXECUTION_IS_HOST is set correctly", 
+    "[PortsOfCall]") {
   // testing this is maybe nontrivial?
-  auto isHost = execution_is_host;
+  auto isHost = PortsOfCall::EXECUTION_IS_HOST;
 
 #if defined(PORTABILITY_STRATEGY_KOKKOS)
   auto checkHost = std::is_same<Kokkos::DefaultExecutionSpace, Kokkos::HostSpace::execution_space>::value;

--- a/test/test_portsofcall.cpp
+++ b/test/test_portsofcall.cpp
@@ -23,10 +23,10 @@ TEST_CASE("portableExecIsHost() returns correctly",
   // testing this is maybe nontrivial?
   auto isHost = portableExecIsHost();
 
-#ifdef PORTABILITY_STRATEGY_KOKKOS
+#if defined(PORTABILITY_STRATEGY_KOKKOS)
   auto checkHost = std::is_same<Kokkos::DefaultExecutionSpace, Kokkos::HostSpace::execution_space>::value;
   REQUIRE( isHost == checkHost );
-#elif PORTABILITY_STRATEGY_CUDA
+#elif defined(PORTABILITY_STRATEGY_CUDA)
   REQUIRE( isHost == false );
 #else
   REQUIRE( isHost == true );

--- a/test/test_portsofcall.cpp
+++ b/test/test_portsofcall.cpp
@@ -18,10 +18,10 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch2/catch.hpp"
 
-TEST_CASE("portableExecIsHost() returns correctly", 
-    "[portableExecIsHost]") {
+TEST_CASE("execution_is_host is set correctly", 
+    "[portibility flags]") {
   // testing this is maybe nontrivial?
-  auto isHost = portableExecIsHost();
+  auto isHost = execution_is_host;
 
 #if defined(PORTABILITY_STRATEGY_KOKKOS)
   auto checkHost = std::is_same<Kokkos::DefaultExecutionSpace, Kokkos::HostSpace::execution_space>::value;

--- a/test/test_portsofcall.cpp
+++ b/test/test_portsofcall.cpp
@@ -18,6 +18,22 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch2/catch.hpp"
 
+TEST_CASE("portableExecIsHost() returns correctly", 
+    "[portableExecIsHost]") {
+  // testing this is maybe nontrivial?
+  auto isHost = portableExecIsHost();
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  auto checkHost = std::is_same<Kokkos::DefaultExecutionSpace, Kokkos::HostSpace::execution_space>::value;
+  REQUIRE( isHost == checkHost );
+#elif PORTABILITY_STRATEGY_CUDA
+  REQUIRE( isHost == false );
+#else
+  REQUIRE( isHost == true );
+#endif
+
+}
+
 // this test is lifted directly from `spiner`;
 // and there appears to be a significant amount of
 // ports-of-call testing done there.


### PR DESCRIPTION
## PR Summary

Adds `portableExecIsHost()` function that returns `true` if the execution space is on host, `false` if on device.

For `PORTABILITY_STRATEGY_KOKKOS`, compares `Kokkos::DefaultExecutionSpace` to `Kokkos::HostSpace::execution_space`. This can differentiate between `openmp` and `cuda`, for instance

For the explicit `PORTABILITY_STRATEGY_*`, just return `true` or `false` as expected.

This maybe useful e.g. https://github.com/lanl/spiner/pull/64

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [x] Install test passes.
- [x] Docs build.
- [x] If preparing for a new release, update the version in cmake.
