### PR TITLE
removed inline, icpc complains

### DIFF
--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -95,11 +95,11 @@ namespace PortsOfCall{
 // compile-time constant to check if execution of memory space
 // will be done on the host or is offloaded
 #if defined(PORTABILITY_STRATEGY_KOKKOS)
-inline constexpr bool EXECUTION_IS_HOST{Kokkos::SpaceAccessibility<Kokkos::DefaultExecutionSpace::memory_space,Kokkos::HostSpace>::accessible};
+constexpr bool EXECUTION_IS_HOST{Kokkos::SpaceAccessibility<Kokkos::DefaultExecutionSpace::memory_space,Kokkos::HostSpace>::accessible};
 #elif defined(PORTABILITY_STRATEGY_CUDA)
-inline constexpr bool EXECUTION_IS_HOST{false};
+constexpr bool EXECUTION_IS_HOST{false};
 #else
-inline constexpr bool EXECUTION_IS_HOST{true};
+constexpr bool EXECUTION_IS_HOST{true};
 #endif
 } // PortsOfCall
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Remove the `inline` keyword from `EXECUTION_IS_HOST` var; `icpc` doesn't like this

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
