### PR TITLE
First cut at adding printf, help builds.

### DIFF
--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -101,6 +101,15 @@ constexpr bool EXECUTION_IS_HOST{false};
 #else
 constexpr bool EXECUTION_IS_HOST{true};
 #endif
+// portable printf
+template <typename ... Ts>
+PORTABLE_INLINE_FUNCTION void printf(char const * const format, Ts ... ts) {
+  // disable for hip
+#ifndef __HIPCC__
+  std::printf(format, ts...);
+#endif // __HIPCC__
+  return;
+}
 } // PortsOfCall
 
 template <typename T>

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -28,11 +28,6 @@
 // TODO(JMM): Is relative path right here?
 #include "portability.hpp"
 
-// use kokkos printf if available
-//#ifdef PORTABILITY_STRATEGY_KOKKOS
-//#include <Kokkos_Printf.hpp>
-//#endif // PORTABILITY_STRATEGY_KOKKOS
-
 // Use these macros for error handling. A macro is required, as
 // opposed to a function, so that the file name and line number can be
 // pulled from the call site.
@@ -106,18 +101,6 @@ namespace impl {
   std::abort();
 #endif // PORTABILITY_STRATEGY_KOKKOS
 }
-
-template <typename ... Ts>
-PORTABLE_INLINE_FUNCTION void printf(char const * const format, Ts ... ts) {
-//#ifdef PORTABILITY_STRATEGY_KOKKOS
-//  Kokkos::printf(format, ts...);
-//#else
-#ifndef __HIPCC__
-  std::printf(format, ts...);
-#endif // __HIPCC__
-//#endif // PORTABILITY_STRATEGY_KOKKOS
-  return;
-}
 } // namespace impl
 
 // Prints an error message describing the failed condition in an
@@ -128,8 +111,9 @@ PORTABLE_INLINE_FUNCTION void require(bool condition_bool,
                                       const char *const message,
                                       const char *const filename,
                                       int const linenumber) {
+  using PortsOfCall::printf;
   if (!condition_bool) {
-    impl::printf(
+    printf(
         "### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
         "%s\n  Line number: %i\n",
         condition, message, filename, linenumber);
@@ -151,7 +135,8 @@ inline void require(bool condition_bool, const char *const condition,
 [[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message,
                                                  const char *const filename,
                                                  int const linenumber) {
-  impl::printf(
+  using PortsOfCall::printf;
+  printf(
       "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
       message, filename, linenumber);
   impl::abort();
@@ -194,7 +179,8 @@ inline void require(bool condition_bool, const char *const condition,
 PORTABLE_INLINE_FUNCTION
 void warn(const char *const message, const char *const filename,
           int const linenumber) {
-  impl::printf(
+  using PortsOfCall::printf;
+  printf(
       "### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "
       "%i\n",
       message, filename, linenumber);

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -28,6 +28,11 @@
 // TODO(JMM): Is relative path right here?
 #include "portability.hpp"
 
+// use kokkos printf if available
+//#ifdef PORTABILITY_STRATEGY_KOKKOS
+//#include <Kokkos_Printf.hpp>
+//#endif // PORTABILITY_STRATEGY_KOKKOS
+
 // Use these macros for error handling. A macro is required, as
 // opposed to a function, so that the file name and line number can be
 // pulled from the call site.
@@ -101,6 +106,18 @@ namespace impl {
   std::abort();
 #endif // PORTABILITY_STRATEGY_KOKKOS
 }
+
+template <typename ... Ts>
+PORTABLE_INLINE_FUNCTION void printf(char const * const format, Ts ... ts) {
+//#ifdef PORTABILITY_STRATEGY_KOKKOS
+//  Kokkos::printf(format, ts...);
+//#else
+#ifndef __HIPCC__
+  std::printf(format, ts...);
+#endif // __HIPCC__
+//#endif // PORTABILITY_STRATEGY_KOKKOS
+  return;
+}
 } // namespace impl
 
 // Prints an error message describing the failed condition in an
@@ -112,7 +129,7 @@ PORTABLE_INLINE_FUNCTION void require(bool condition_bool,
                                       const char *const filename,
                                       int const linenumber) {
   if (!condition_bool) {
-    std::printf(
+    impl::printf(
         "### ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
         "%s\n  Line number: %i\n",
         condition, message, filename, linenumber);
@@ -134,7 +151,7 @@ inline void require(bool condition_bool, const char *const condition,
 [[noreturn]] PORTABLE_INLINE_FUNCTION void abort(const char *const message,
                                                  const char *const filename,
                                                  int const linenumber) {
-  std::printf(
+  impl::printf(
       "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
       message, filename, linenumber);
   impl::abort();
@@ -177,7 +194,7 @@ inline void require(bool condition_bool, const char *const condition,
 PORTABLE_INLINE_FUNCTION
 void warn(const char *const message, const char *const filename,
           int const linenumber) {
-  std::printf(
+  impl::printf(
       "### WARNING\n  Message:     %s\n  File:        %s\n  Line number: "
       "%i\n",
       message, filename, linenumber);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This adds an internal print function used by portable errors machinery that stubs out printf on hip where printf doesn't exist.

- [ ] Should we make this more public for use by downstream codes (probably).
- [ ] Should we figure out a way to call out to kokkos printf if its available (only available on very new versions of kokkos).

@Yurlungur @mauneyc-LANL @rbberger @chadmeyer 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
