### PR TITLE
Change 'condition' to 'condition_bool'

### DIFF
--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -128,7 +128,7 @@ inline void require(bool condition_bool, const char *const condition,
 inline void require(bool condition_bool, const char *const condition,
                     std::stringstream const &message,
                     const char *const filename, int const linenumber) {
-  require(condition, condition, message.str().c_str(), filename, linenumber);
+  require(condition_bool, condition, message.str().c_str(), filename, linenumber);
 }
 
 // Prints an error message with file name and line number and then aborts.


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Quick fix to what appears to be a bug where `condition` was twice in the wrapper for `require()`. This affects the string stream implementation of `PORTABLE_REQUIRE`.

Fixes #43 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [x] Install test passes.
- [x] Docs build.
- N/A If preparing for a new release, update the version in cmake.
