### PR TITLE
add CI tests and add catch v3 to spackage

### DIFF
--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -1,0 +1,29 @@
+name: Tests minimal
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+    tests:
+      name: Minimal test suite
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+          with:
+            submodules: recursive
+        - name: Set system to non-interactive mode
+          run: export DEBIAN_FRONTEND=noninteractive
+        - name: install dependencies
+          run: |
+            sudo apt-get install -y --force-yes -qq build-essential
+        - name: build and install
+          run: |
+            mkdir -p buld && cd build
+            cmake -DPORTS_OF_CALL_BUILD_TESTING=ON ..
+            make -j
+            make test

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -23,7 +23,8 @@ jobs:
             sudo apt-get install -y --force-yes -qq build-essential
         - name: build and install
           run: |
-            mkdir -p buld && cd build
+            mkdir -p buld
+            cd build
             cmake -DPORTS_OF_CALL_BUILD_TESTING=ON ..
             make -j
             make test

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -23,7 +23,7 @@ jobs:
             sudo apt-get install -y --force-yes -qq build-essential
         - name: build and install
           run: |
-            mkdir -p buld
+            mkdir -p build
             cd build
             cmake -DPORTS_OF_CALL_BUILD_TESTING=ON ..
             make -j

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -41,8 +41,10 @@ class PortsOfCall(CMakePackage):
         default="None",
         when="@:1.2.0",
     )
+    variant("test", default=False, description="Build tests")
 
     depends_on("cmake@3.12:")
+    depends_on("catch2@3.0.1:", when"+test")
 
     def cmake_args(self):
         args = []

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -47,7 +47,9 @@ class PortsOfCall(CMakePackage):
     depends_on("catch2@3.0.1:", when"+test")
 
     def cmake_args(self):
-        args = []
+        args = [
+            self.define_from_variant("PORTS_OF_CALL_BUILD_TESTING", "test"),
+        ]
         if self.spec.satisfies("@:1.2.0"):
             args.append(self.define_from_variant("PORTABILITY_STRATEGY", "portability_strategy"))
         return args


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I just noticed that the tests in ports-of-call aren't run on either re-git or github. This at least adds them to the github CI. I also add a test variant and catch2 v3 dependency to the spackage.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
