### PR TITLE
move target logic into test cmakelist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ cmake_minimum_required(VERSION 3.14)
 set(PORTS_OF_CALL_VERSION 1.6.0)
 project(ports-of-call VERSION ${PORTS_OF_CALL_VERSION})
 
+# dependent options
+include(CMakeDependentOption)
+
 # CMAKE WARMUP
 # ----------------------------------------
 
@@ -32,6 +35,10 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 option (PORTS_OF_CALL_BUILD_TESTING "Test the current installation")
+# off by default but possible to turn on
+cmake_dependent_option(PORTS_OF_CALL_TEST_USE_KOKKOS
+  "Use Kokkos offloading for tests"
+  OFF "PORTS_OF_CALL_BUILD_TESTING" OFF)
 
 # CONFIGURATION LOGIC
 # ----------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,14 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     "Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
 endif()
 
-option (PORTS_OF_CALL_BUILD_TESTING "Test the current installation")
+option (PORTS_OF_CALL_BUILD_TESTING "Test the current installation" OFF)
 # off by default but possible to turn on
-cmake_dependent_option(PORTS_OF_CALL_TEST_USE_KOKKOS
-  "Use Kokkos offloading for tests"
-  OFF "PORTS_OF_CALL_BUILD_TESTING" OFF)
+if (PORTS_OF_CALL_BUILD_TESTING)
+  set(PORTS_OF_CALL_TEST_PORTABILITY_STRATEGY "None" CACHE STRING
+    "Portability strategy used by tests")
+  set_property(CACHE PORTS_OF_CALL_TEST_PORTABILITY_STRATEGY
+    PROPERTY STRINGS None Cuda Kokkos)
+endif()
 
 # CONFIGURATION LOGIC
 # ----------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,6 @@ cmake_minimum_required(VERSION 3.14)
 set(PORTS_OF_CALL_VERSION 1.6.0)
 project(ports-of-call VERSION ${PORTS_OF_CALL_VERSION})
 
-# dependent options
-include(CMakeDependentOption)
-
 # CMAKE WARMUP
 # ----------------------------------------
 

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -44,7 +44,7 @@ class PortsOfCall(CMakePackage):
     variant("test", default=False, description="Build tests")
 
     depends_on("cmake@3.12:")
-    depends_on("catch2@3.0.1:", when"+test")
+    depends_on("catch2@3.0.1:", when="+test")
 
     def cmake_args(self):
         args = [

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 # this interface target is to collect
 # compile/link options for the test
 add_library(portsofcall_iface INTERFACE)
-if (PORTABILITY_STRATEGY_KOKKOS)
+if (PORTS_OF_CALL_TEST_USE_KOKKOS)
   if(NOT TARGET Kokkos::kokkos)
     find_package(Kokkos REQUIRED)
   endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,6 @@ if(NOT TARGET Catch2::Catch2)
   find_package(Catch2 QUIET)
   if(NOT Catch2_FOUND)
     message(STATUS "Fetching Catch2 as needed")
-    # idiomatic FetchContent
     include(FetchContent)
     FetchContent_Declare(
       Catch2
@@ -29,14 +28,28 @@ endif()
 # this interface target is to collect
 # compile/link options for the test
 add_library(portsofcall_iface INTERFACE)
-if (PORTS_OF_CALL_TEST_USE_KOKKOS)
+if (PORTS_OF_CALL_TEST_PORTABILITY_STRATEGY STREQUAL "Kokkos")
   if(NOT TARGET Kokkos::kokkos)
-    find_package(Kokkos REQUIRED)
+    find_package(Kokkos QUIET)
+    if(NOT Kokkos_FOUND)
+      message(STATUS "Fetching Kokkos as needed")
+      include(FetchContent)
+      FetchContent_Declare(
+        Kokkos
+        GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+        # This is most recent but any version that supports C++17 is
+        # fine
+        GIT_TAG 4.3.01)
+      FetchContent_MakeAvailable(Kokkos)
+    endif()
   endif()
 
   target_link_libraries(portsofcall_iface INTERFACE Kokkos::kokkos)
   # this comes with ports-of-call target
   target_compile_definitions(portsofcall_iface INTERFACE PORTABILITY_STRATEGY_KOKKOS)
+elseif (PORTS_OF_CALL_TEST_PORTABILITY_STRATEGY STREQUAL "Cuda")
+  message(FATAL_ERROR "Cuda tests not yet fully supported")
+  target_compile_definitions(portsofcall_iface INTERFACE PORTABILITY_STRATEGY_CUDA)
 endif()
 
 target_link_libraries(portsofcall_iface INTERFACE Catch2::Catch2)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Ports of call doesn't set the portability strategy in cmake. Must be set downstream. Here we fix the tests so it is set for testing purposes.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
