### PR TITLE
Conformant span

### DIFF
--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -230,3 +230,24 @@ not yet ``constexpr``, so even with the "relaxed ``constexpr``" compilation mode
 not feature-complete on GPUs.  This will change when those member functions become ``constexpr`` in
 C++20.
 
+span.hpp
+
+
+``PortsOfCall::span`` is implements ``std::span`` for C++17 (uses native implmentation in C++20) 
+as a view over contiguous data. ``span`` may have compile-time static extent, or a dynamic extent. 
+``span`` provides iterator functions similar to containers.
+
+.. code-block:: cpp
+  
+ int arr[] = {1, 2, 3};
+ auto s = span{arr};
+ for(auto & i : s)
+ {
+   i -= 1;
+ }
+
+``span::subspan`` returns a span over a subrange. Element access uses ``span::operator[]``. For 
+more information, see `C++ reference page <https://en.cppreference.com/w/cpp/container/span>`_.
+
+
+

--- a/ports-of-call/span.hh
+++ b/ports-of-call/span.hh
@@ -141,10 +141,7 @@ class span {
   constexpr span(pointer ptr, size_type count) : storage_(ptr, count) {}
 
   constexpr span(pointer first_elem, pointer last_elem)
-      : storage_(first_elem, last_elem - first_elem) {
-    TCB_SPAN_EXPECT(extent == dynamic_extent ||
-                    last_elem - first_elem == static_cast<std::ptrdiff_t>(extent));
-  }
+      : storage_(first_elem, last_elem - first_elem) {}
 
   template <std::size_t N, std::size_t E = Extent,
             typename std::enable_if<(E == dynamic_extent || N == E) &&
@@ -202,13 +199,11 @@ class span {
   // [span.sub], span subviews
   template <std::size_t Count>
   constexpr span<element_type, Count> first() const {
-    TCB_SPAN_EXPECT(Count <= size());
     return {data(), Count};
   }
 
   template <std::size_t Count>
   constexpr span<element_type, Count> last() const {
-    TCB_SPAN_EXPECT(Count <= size());
     return {data() + (size() - Count), Count};
   }
 
@@ -221,26 +216,24 @@ class span {
 
   template <std::size_t Offset, std::size_t Count = dynamic_extent>
   constexpr subspan_return_t<Offset, Count> subspan() const {
-    TCB_SPAN_EXPECT(Offset <= size() &&
                     (Count == dynamic_extent || Offset + Count <= size()));
-    return {data() + Offset, Count != dynamic_extent ? Count : size() - Offset};
+                    return {data() + Offset,
+                            Count != dynamic_extent ? Count : size() - Offset};
   }
 
   constexpr span<element_type, dynamic_extent> first(size_type count) const {
-    TCB_SPAN_EXPECT(count <= size());
     return {data(), count};
   }
 
   constexpr span<element_type, dynamic_extent> last(size_type count) const {
-    TCB_SPAN_EXPECT(count <= size());
     return {data() + (size() - count), count};
   }
 
   constexpr span<element_type, dynamic_extent>
   subspan(size_type offset, size_type count = dynamic_extent) const {
-    TCB_SPAN_EXPECT(offset <= size() &&
                     (count == dynamic_extent || offset + count <= size()));
-    return {data() + offset, count == dynamic_extent ? size() - offset : count};
+                    return {data() + offset,
+                            count == dynamic_extent ? size() - offset : count};
   }
 
   // [span.obs], span observers
@@ -253,20 +246,11 @@ class span {
   [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
 
   // [span.elem], span element access
-  constexpr reference operator[](size_type idx) const {
-    TCB_SPAN_EXPECT(idx < size());
-    return *(data() + idx);
-  }
+  constexpr reference operator[](size_type idx) const { return *(data() + idx); }
 
-  constexpr reference front() const {
-    TCB_SPAN_EXPECT(!empty());
-    return *data();
-  }
+  constexpr reference front() const { return *data(); }
 
-  constexpr reference back() const {
-    TCB_SPAN_EXPECT(!empty());
-    return *(data() + (size() - 1));
-  }
+  constexpr reference back() const { return *(data() + (size() - 1)); }
 
   constexpr pointer data() const noexcept { return storage_.ptr; }
 

--- a/ports-of-call/span.hh
+++ b/ports-of-call/span.hh
@@ -1,0 +1,375 @@
+#ifndef PORTS_OF_CALL_SPAN_HH_
+#define PORTS_OF_CALL_SPAN_HH_
+
+#include <cstdio>
+#include <stdexcept>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace PortsOfCall::span {
+
+using std::byte;
+using std::void_t;
+
+// set dynamic_extent to maximum integer size
+constexpr std::size_t dynamic_extent = SIZE_MAX;
+
+// forward declare
+template <typename ElementType, std::size_t Extent = dynamic_extent>
+class span;
+
+namespace detail {
+
+using std::data;
+using std::size;
+
+// object to handle storage of span
+template <typename E, std::size_t S>
+struct span_storage {
+  constexpr span_storage() noexcept = default;
+
+  constexpr span_storage(E *p_ptr, std::size_t /*unused*/) noexcept : ptr(p_ptr) {}
+
+  E *ptr = nullptr;
+  static constexpr std::size_t size = S;
+};
+
+// specialization for dynamic_extent
+template <typename E>
+struct span_storage<E, dynamic_extent> {
+  constexpr span_storage() noexcept = default;
+
+  constexpr span_storage(E *p_ptr, std::size_t p_size) noexcept
+      : ptr(p_ptr), size(p_size) {}
+
+  E *ptr = nullptr;
+  std::size_t size = 0;
+};
+
+// some metaprogramming
+template <class T>
+using uncvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+template <class>
+struct is_span : std::false_type {};
+
+template <class T, std::size_t S>
+struct is_span<span<T, S>> : std::true_type {};
+
+template <class>
+struct is_std_array : std::false_type {};
+
+template <class T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template <class, typename = void>
+struct has_size_and_data : std::false_type {};
+
+template <class T>
+struct has_size_and_data<T, void_t<decltype(detail::size(std::declval<T>())),
+                                   decltype(detail::data(std::declval<T>()))>>
+    : std::true_type {};
+
+template <class C, typename U = uncvref_t<C>>
+struct is_container {
+  static constexpr bool value = !is_span<U>::value && !is_std_array<U>::value &&
+                                !std::is_array<U>::value && has_size_and_data<C>::value;
+};
+
+template <class T>
+using remove_pointer_t = class std::remove_pointer<T>::type;
+
+template <class, class, class = void>
+struct is_container_element_type_compatible : std::false_type {};
+
+// checks to insure that container T and element E are compatible
+template <class T, class E>
+struct is_container_element_type_compatible<
+    T, E,
+    typename std::enable_if<!std::is_same<typename std::remove_cv<decltype(detail::data(
+                                              std::declval<T>()))>::type,
+                                          void>::value &&
+                            std::is_convertible<remove_pointer_t<decltype(detail::data(
+                                                    std::declval<T>()))> (*)[],
+                                                E (*)[]>::value>::type> : std::true_type {
+};
+
+template <class, class = size_t>
+struct is_complete : std::false_type {};
+
+template <class T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+
+} // namespace detail
+
+template <class ElementType, std::size_t Extent>
+class span {
+  static_assert(std::is_object<ElementType>::value,
+                "A span's ElementType must be an object type (not a "
+                "reference type or void)");
+  static_assert(detail::is_complete<ElementType>::value,
+                "A span's ElementType must be a complete type (not a forward "
+                "declaration)");
+  static_assert(!std::is_abstract<ElementType>::value,
+                "A span's ElementType cannot be an abstract class type");
+
+  using storage_type = detail::span_storage<ElementType, Extent>;
+
+ public:
+  // constants and types
+  using element_type = ElementType;
+  using value_type = typename std::remove_cv<ElementType>::type;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using pointer = element_type *;
+  using const_pointer = const element_type *;
+  using reference = element_type &;
+  using const_reference = const element_type &;
+  using iterator = pointer;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+
+  static constexpr size_type extent = Extent;
+
+  // [span.cons], span constructors, copy, assignment, and destructor
+  template <std::size_t E = Extent,
+            typename std::enable_if<(E == dynamic_extent || E <= 0), int>::type = 0>
+  constexpr span() noexcept {}
+
+  constexpr span(pointer ptr, size_type count) : storage_(ptr, count) {}
+
+  constexpr span(pointer first_elem, pointer last_elem)
+      : storage_(first_elem, last_elem - first_elem) {
+    TCB_SPAN_EXPECT(extent == dynamic_extent ||
+                    last_elem - first_elem == static_cast<std::ptrdiff_t>(extent));
+  }
+
+  template <std::size_t N, std::size_t E = Extent,
+            typename std::enable_if<(E == dynamic_extent || N == E) &&
+                                        detail::is_container_element_type_compatible<
+                                            element_type (&)[N], ElementType>::value,
+                                    int>::type = 0>
+  constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N) {}
+
+  template <class T, std::size_t N, std::size_t E = Extent,
+            typename std::enable_if<(E == dynamic_extent || N == E) &&
+                                        detail::is_container_element_type_compatible<
+                                            std::array<T, N> &, ElementType>::value,
+                                    int>::type = 0>
+  constexpr span(std::array<T, N> &arr) noexcept : storage_(arr.data(), N) {}
+
+  template <class T, std::size_t N, std::size_t E = Extent,
+            typename std::enable_if<(E == dynamic_extent || N == E) &&
+                                        detail::is_container_element_type_compatible<
+                                            const std::array<T, N> &, ElementType>::value,
+                                    int>::type = 0>
+  constexpr span(const std::array<T, N> &arr) noexcept : storage_(arr.data(), N) {}
+
+  template <class Container, std::size_t E = Extent,
+            typename std::enable_if<E == dynamic_extent &&
+                                        detail::is_container<Container>::value &&
+                                        detail::is_container_element_type_compatible<
+                                            Container &, ElementType>::value,
+                                    int>::type = 0>
+  constexpr span(Container &cont) : storage_(detail::data(cont), detail::size(cont)) {}
+
+  template <class Container, std::size_t E = Extent,
+            typename std::enable_if<E == dynamic_extent &&
+                                        detail::is_container<Container>::value &&
+                                        detail::is_container_element_type_compatible<
+                                            const Container &, ElementType>::value,
+                                    int>::type = 0>
+  constexpr span(const Container &cont)
+      : storage_(detail::data(cont), detail::size(cont)) {}
+
+  constexpr span(const span &other) noexcept = default;
+
+  template <class OtherElementType, std::size_t OtherExtent,
+            typename std::enable_if<
+                (Extent == dynamic_extent || OtherExtent == dynamic_extent ||
+                 Extent == OtherExtent) &&
+                    std::is_convertible<OtherElementType (*)[], ElementType (*)[]>::value,
+                int>::type = 0>
+  constexpr span(const span<OtherElementType, OtherExtent> &other) noexcept
+      : storage_(other.data(), other.size()) {}
+
+  ~span() noexcept = default;
+
+  constexpr span &operator=(const span &other) noexcept = default;
+
+  // [span.sub], span subviews
+  template <std::size_t Count>
+  constexpr span<element_type, Count> first() const {
+    TCB_SPAN_EXPECT(Count <= size());
+    return {data(), Count};
+  }
+
+  template <std::size_t Count>
+  constexpr span<element_type, Count> last() const {
+    TCB_SPAN_EXPECT(Count <= size());
+    return {data() + (size() - Count), Count};
+  }
+
+  template <std::size_t Offset, std::size_t Count = dynamic_extent>
+  using subspan_return_t =
+      span<ElementType,
+           Count != dynamic_extent
+               ? Count
+               : (Extent != dynamic_extent ? Extent - Offset : dynamic_extent)>;
+
+  template <std::size_t Offset, std::size_t Count = dynamic_extent>
+  constexpr subspan_return_t<Offset, Count> subspan() const {
+    TCB_SPAN_EXPECT(Offset <= size() &&
+                    (Count == dynamic_extent || Offset + Count <= size()));
+    return {data() + Offset, Count != dynamic_extent ? Count : size() - Offset};
+  }
+
+  constexpr span<element_type, dynamic_extent> first(size_type count) const {
+    TCB_SPAN_EXPECT(count <= size());
+    return {data(), count};
+  }
+
+  constexpr span<element_type, dynamic_extent> last(size_type count) const {
+    TCB_SPAN_EXPECT(count <= size());
+    return {data() + (size() - count), count};
+  }
+
+  constexpr span<element_type, dynamic_extent>
+  subspan(size_type offset, size_type count = dynamic_extent) const {
+    TCB_SPAN_EXPECT(offset <= size() &&
+                    (count == dynamic_extent || offset + count <= size()));
+    return {data() + offset, count == dynamic_extent ? size() - offset : count};
+  }
+
+  // [span.obs], span observers
+  constexpr size_type size() const noexcept { return storage_.size; }
+
+  constexpr size_type size_bytes() const noexcept {
+    return size() * sizeof(element_type);
+  }
+
+  [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
+
+  // [span.elem], span element access
+  constexpr reference operator[](size_type idx) const {
+    TCB_SPAN_EXPECT(idx < size());
+    return *(data() + idx);
+  }
+
+  constexpr reference front() const {
+    TCB_SPAN_EXPECT(!empty());
+    return *data();
+  }
+
+  constexpr reference back() const {
+    TCB_SPAN_EXPECT(!empty());
+    return *(data() + (size() - 1));
+  }
+
+  constexpr pointer data() const noexcept { return storage_.ptr; }
+
+  // [span.iterators], span iterator support
+  constexpr iterator begin() const noexcept { return data(); }
+
+  constexpr iterator end() const noexcept { return data() + size(); }
+
+  constexpr reverse_iterator rbegin() const noexcept { return reverse_iterator(end()); }
+
+  constexpr reverse_iterator rend() const noexcept { return reverse_iterator(begin()); }
+
+ private:
+  storage_type storage_{};
+};
+
+template <class T, size_t N>
+span(T (&)[N]) -> span<T, N>;
+
+template <class T, size_t N>
+span(std::array<T, N> &) -> span<T, N>;
+
+template <class T, size_t N>
+span(const std::array<T, N> &) -> span<const T, N>;
+
+template <class Container>
+span(Container &) -> span<typename std::remove_reference<
+                      decltype(*detail::data(std::declval<Container &>()))>::type>;
+
+template <class Container>
+span(const Container &) -> span<const typename Container::value_type>;
+
+template <class ElementType, std::size_t Extent>
+constexpr span<ElementType, Extent> make_span(span<ElementType, Extent> s) noexcept {
+  return s;
+}
+
+template <class T, std::size_t N>
+constexpr span<T, N> make_span(T (&arr)[N]) noexcept {
+  return {arr};
+}
+
+template <class T, std::size_t N>
+constexpr span<T, N> make_span(std::array<T, N> &arr) noexcept {
+  return {arr};
+}
+
+template <class T, std::size_t N>
+constexpr span<const T, N> make_span(const std::array<T, N> &arr) noexcept {
+  return {arr};
+}
+
+template <class Container>
+constexpr span<typename std::remove_reference<
+    decltype(*detail::data(std::declval<Container &>()))>::type>
+make_span(Container &cont) {
+  return {cont};
+}
+
+template <class Container>
+constexpr span<const typename Container::value_type> make_span(const Container &cont) {
+  return {cont};
+}
+
+template <class ElementType, std::size_t Extent>
+span<const byte,
+     ((Extent == dynamic_extent) ? dynamic_extent : sizeof(ElementType) * Extent)>
+as_bytes(span<ElementType, Extent> s) noexcept {
+  return {reinterpret_cast<const byte *>(s.data()), s.size_bytes()};
+}
+
+template <class ElementType, size_t Extent,
+          typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
+span<byte, ((Extent == dynamic_extent) ? dynamic_extent : sizeof(ElementType) * Extent)>
+as_writable_bytes(span<ElementType, Extent> s) noexcept {
+  return {reinterpret_cast<byte *>(s.data()), s.size_bytes()};
+}
+
+template <std::size_t N, class E, std::size_t S>
+constexpr auto get(span<E, S> s) -> decltype(s[N]) {
+  return s[N];
+}
+
+} // namespace PortsOfCall::span
+
+namespace std {
+
+template <class ElementType, size_t Extent>
+class tuple_size<PortsOfCall::span::span<ElementType, Extent>>
+    : public integral_constant<size_t, Extent> {};
+
+template <class ElementType>
+class tuple_size<
+    PortsOfCall::span::span<ElementType, PortsOfCall::span::dynamic_extent>>; // not
+                                                                              // defined
+
+template <size_t I, class ElementType, size_t Extent>
+class tuple_element<I, PortsOfCall::span::span<ElementType, Extent>> {
+ public:
+  static_assert(Extent != PortsOfCall::span::dynamic_extent && I < Extent, "");
+  using type = ElementType;
+};
+
+} // end namespace std
+
+#endif

--- a/ports-of-call/span.hpp
+++ b/ports-of-call/span.hpp
@@ -217,31 +217,18 @@ class span {
             span_REQUIRES(
                 (E == dynamic_extent || N == E) &&
                 detail::is_compatible_container<element_type (&)[N], ElementType>::value)>
-  // typename std::enable_if<(E == dynamic_extent || N == E) &&
-  //                             detail::is_compatible_container<
-  //                                 element_type (&)[N], ElementType>::value,
-  //                         int>::type = 0>
   constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N) {}
 
   template <class T, std::size_t N, std::size_t E = Extent,
             span_REQUIRES(
                 (E == dynamic_extent || N == E) &&
                 detail::is_compatible_container<std::array<T, N> &, ElementType>::value)>
-
-  // typename std::enable_if<(E == dynamic_extent || N == E) &&
-  //                             detail::is_compatible_container<
-  //                                 std::array<T, N> &, ElementType>::value,
-  //                         int>::type = 0>
   constexpr span(std::array<T, N> &arr) noexcept : storage_(arr.data(), N) {}
 
   template <class T, std::size_t N, std::size_t E = Extent,
             span_REQUIRES((E == dynamic_extent || N == E) &&
                           detail::is_compatible_container<const std::array<T, N> &,
                                                           ElementType>::value)>
-  // typename std::enable_if<(E == dynamic_extent || N == E) &&
-  //                             detail::is_compatible_container<
-  //                                 const std::array<T, N> &, ElementType>::value,
-  //                         int>::type = 0>
   constexpr span(const std::array<T, N> &arr) noexcept : storage_(arr.data(), N) {}
 
   // constructs a span that is a view of cont
@@ -254,10 +241,6 @@ class span {
       class Container, std::size_t E = Extent,
       span_REQUIRES(E == dynamic_extent && detail::is_container<Container>::value &&
                     detail::is_compatible_container<Container &, ElementType>::value)>
-  // typename std::enable_if<
-  //     E == dynamic_extent && detail::is_container<Container>::value &&
-  //         detail::is_compatible_container<Container &, ElementType>::value,
-  //     int>::type = 0>
   constexpr span(Container &cont) noexcept
       : storage_(detail::data(cont), detail::size(cont)) {}
 
@@ -265,10 +248,6 @@ class span {
             span_REQUIRES(
                 E == dynamic_extent && detail::is_container<Container>::value &&
                 detail::is_compatible_container<const Container &, ElementType>::value)>
-  // typename std::enable_if<
-  //     E == dynamic_extent && detail::is_container<Container>::value &&
-  //         detail::is_compatible_container<const Container &, ElementType>::value,
-  //     int>::type = 0>
   constexpr span(const Container &cont) noexcept
       : storage_(detail::data(cont), detail::size(cont)) {}
 
@@ -279,11 +258,6 @@ class span {
                 (Extent == dynamic_extent || OtherExtent == dynamic_extent ||
                  Extent == OtherExtent) &&
                 std::is_convertible<OtherElementType (*)[], ElementType (*)[]>::value)>
-  // typename std::enable_if<
-  //     (Extent == dynamic_extent || OtherExtent == dynamic_extent ||
-  //      Extent == OtherExtent) &&
-  //         std::is_convertible<OtherElementType (*)[], ElementType (*)[]>::value,
-  //     int>::type = 0>
   constexpr span(const span<OtherElementType, OtherExtent> &other) noexcept
       : storage_(other.data(), other.size()) {
     span_EXPECTS(OtherExtent == dynamic_extent || other.size() == OtherExtent);
@@ -456,7 +430,6 @@ as_bytes(span<ElementType, Extent> s) noexcept {
 
 template <class ElementType, size_t Extent,
           span_REQUIRES(!std::is_const<ElementType>::value)>
-//          typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
 span<byte, ((Extent == dynamic_extent) ? dynamic_extent : sizeof(ElementType) * Extent)>
 as_writable_bytes(span<ElementType, Extent> s) noexcept {
   return {reinterpret_cast<byte *>(s.data()), s.size_bytes()};

--- a/ports-of-call/span.hpp
+++ b/ports-of-call/span.hpp
@@ -238,16 +238,18 @@ class span {
   template <
       class Container, std::size_t E = Extent,
       span_REQUIRES(E == dynamic_extent && detail::is_container<Container>::value &&
-                    detail::is_compatible_container<Container &, ElementType>::value)>
-  constexpr span(Container &cont) noexcept
+                    detail::is_compatible_container<Container &, ElementType>::value &&
+                    !std::is_rvalue_reference<Container &&>::value)>
+  constexpr span(Container &&cont) noexcept
       : storage_(detail::data(cont), detail::size(cont)) {}
 
-  template <class Container, std::size_t E = Extent,
-            span_REQUIRES(
-                E == dynamic_extent && detail::is_container<Container>::value &&
-                detail::is_compatible_container<const Container &, ElementType>::value)>
-  constexpr span(const Container &cont) noexcept
-      : storage_(detail::data(cont), detail::size(cont)) {}
+  // template <class Container, std::size_t E = Extent,
+  //           span_REQUIRES(
+  //               E == dynamic_extent && detail::is_container<Container>::value &&
+  //               detail::is_compatible_container<const Container &,
+  //               ElementType>::value)>
+  // constexpr span(const Container &cont) noexcept
+  //     : storage_(detail::data(cont), detail::size(cont)) {}
 
   constexpr span(const span &other) noexcept = default;
 

--- a/ports-of-call/span.hpp
+++ b/ports-of-call/span.hpp
@@ -186,9 +186,7 @@ class span {
   // constructs an empty span
   // - data() == nullptr
   // - size() == 0
-  template <std::size_t E = Extent,
-            // span_REQUIRES(E == dynamic_extent || E <= 0 ) >
-            typename std::enable_if<(E == dynamic_extent || E <= 0), int>::type = 0>
+  template <std::size_t E = Extent, span_REQUIRES(E == dynamic_extent || E <= 0)>
   constexpr span() noexcept {}
 
   // constructs a span that is a view over the range [first, first+count)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,4 +64,4 @@ target_link_libraries(test_portsofcall
 include(Catch)
 catch_discover_tests(test_portsofcall)
 
-target_sources(test_portsofcall PRIVATE test_portability.cpp test_array.cpp)
+target_sources(test_portsofcall PRIVATE test_portability.cpp test_array.cpp test_span.cpp)

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -62,10 +62,68 @@ TEST_CASE("iter, extent construction", "[PortsOfCall::span]") {
 
   int arr[] = {0, 1, 2};
 
-  span<int, 3> s(arr, 3);
-
   SECTION("dynamic") {
     span<int> s{arr, arr + 3};
+    span_require(s, arr);
+  }
+
+  SECTION("fixed") {
+    span<int, 3> s(arr, 3);
+    span_require(s, arr);
+  }
+}
+
+TEST_CASE("Carr construction", "[PortsOfCall::span]") {
+  using int_array_t = int[3];
+  using real_array_t = double[3];
+
+  static_assert(std::is_nothrow_constructible<span<int>, int_array_t &>::value, "");
+  static_assert(!std::is_constructible<span<int>, int_array_t const &>::value, "");
+  static_assert(!std::is_constructible<span<int>, real_array_t>::value, "");
+
+  static_assert(std::is_nothrow_constructible<span<const int>, int_array_t &>::value, "");
+  static_assert(
+      std::is_nothrow_constructible<span<const int>, int_array_t const &>::value, "");
+  static_assert(!std::is_constructible<span<const int>, real_array_t>::value, "");
+
+  static_assert(std::is_nothrow_constructible<span<int, 3>, int_array_t &>::value, "");
+  static_assert(!std::is_constructible<span<int, 3>, int_array_t const &>::value, "");
+  static_assert(!std::is_constructible<span<int, 3>, real_array_t &>::value, "");
+
+  static_assert(std::is_nothrow_constructible<span<const int, 3>, int_array_t &>::value,
+                "");
+  static_assert(
+      std::is_nothrow_constructible<span<const int, 3>, int_array_t const &>::value, "");
+  static_assert(!std::is_constructible<span<const int, 3>, real_array_t>::value, "");
+
+  static_assert(!std::is_constructible<span<int, 42>, int_array_t &>::value, "");
+  static_assert(!std::is_constructible<span<int, 42>, int_array_t const &>::value, "");
+  static_assert(!std::is_constructible<span<int, 42>, real_array_t &>::value, "");
+
+  static_assert(!std::is_constructible<span<const int, 42>, int_array_t &>::value, "");
+  static_assert(!std::is_constructible<span<const int, 42>, int_array_t const &>::value,
+                "");
+  static_assert(!std::is_constructible<span<const int, 42>, real_array_t &>::value, "");
+
+  int arr[] = {0, 1, 2};
+
+  SECTION("dynamic") {
+    span<int> s{arr};
+    span_require(s, arr);
+  }
+
+  SECTION("dynamic const") {
+    span<const int> s{arr};
+    span_require(s, arr);
+  }
+
+  SECTION("fixed") {
+    span<int, 3> s{arr};
+    span_require(s, arr);
+  }
+
+  SECTION("fixed const") {
+    span<const int, 3> s{arr};
     span_require(s, arr);
   }
 }

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -10,21 +10,84 @@
 
 #define FIXED 10
 
+namespace test {
+
 using namespace PortsOfCall::span;
+
+namespace detail {
+
+// equal, search are the std::equal, std::search but made constexpr
+// this is the C++20 implementation
+template <class InputIt1, class InputIt2>
+constexpr bool equal(InputIt1 first1, InputIt1 last1, InputIt2 first2) {
+  for (; first1 != last1; ++first1, ++first2)
+    if (!(*first1 == *first2)) return false;
+
+  return true;
+}
+
+template <class ForwardIt1, class ForwardIt2>
+constexpr ForwardIt1 search(ForwardIt1 first, ForwardIt1 last, ForwardIt2 s_first,
+                            ForwardIt2 s_last) {
+  while (true) {
+    ForwardIt1 it = first;
+    for (ForwardIt2 s_it = s_first;; ++it, ++s_it) {
+      if (s_it == s_last) return first;
+      if (it == last) return last;
+      if (!(*it == *s_it)) break;
+    }
+    ++first;
+  }
+}
+
+// same as prior, moved to constexpr
+template <class ForwardIt, class Generator>
+constexpr void generate(ForwardIt first, ForwardIt last, Generator g) {
+  for (; first != last; ++first)
+    *first = g();
+}
+
+template <class T, std::size_t N>
+[[nodiscard]]
+constexpr auto slide(span<T, N> s, std::size_t offset, std::size_t width) {
+  return s.subspan(offset, offset + width <= s.size() ? width : 0U);
+}
+
+template <class T, std::size_t N, std::size_t M>
+constexpr bool starts_with(span<T, N> data, span<T, M> prefix) {
+  return data.size() >= prefix.size() &&
+         equal(prefix.begin(), prefix.end(), data.begin());
+}
+
+template <class T, std::size_t N, std::size_t M>
+constexpr bool ends_with(span<T, N> data, span<T, M> suffix) {
+  return data.size() >= suffix.size() &&
+         equal(data.end() - suffix.size(), data.end(), suffix.end() - suffix.size());
+}
+
+template <class T, std::size_t N, std::size_t M>
+constexpr bool contains(span<T, N> s, span<T, M> sub) {
+  return search(s.begin(), s.end(), sub.begin(), sub.end()) != s.end();
+}
+
+} // namespace detail
 
 template <class S, class I, auto N = 3>
 auto span_require(S &&s, I &&i) {
   REQUIRE(s.size() == N);
   REQUIRE(s.data() == i);
-  REQUIRE(s.begin() == std::begin(i));
-  REQUIRE(s.end() == std::end(i));
+  REQUIRE(s.begin() == i);
+  REQUIRE(s.end() == i + N);
 }
 
-TEST_CASE("default construction", "[PortsOfCall::span]") {
-  static_assert(std::is_nothrow_default_constructible<span<int>>::value, "");
-  static_assert(std::is_nothrow_constructible<span<int, 0>>::value, "");
+TEST_CASE("span default construction", "[PortsOfCall::span]") {
+  static_assert(std::is_nothrow_default_constructible<span<int>>::value,
+                "span<int> is not nothrow default constructible");
+  static_assert(std::is_nothrow_constructible<span<int, 0>>::value,
+                "span<int, 0> is not nothrow constructible");
 
-  static_assert(!std::is_nothrow_constructible<span<int, FIXED>>::value, "");
+  static_assert(!std::is_nothrow_constructible<span<int, FIXED>>::value,
+                "span<int, FIXED> is nothrow construcible");
 
   SECTION("dynamic size") {
     constexpr span<int> s{};
@@ -45,7 +108,7 @@ TEST_CASE("default construction", "[PortsOfCall::span]") {
   }
 }
 
-TEST_CASE("iter, extent construction", "[PortsOfCall::span]") {
+TEST_CASE("span iter, extent construction", "[PortsOfCall::span]") {
   static_assert(std::is_constructible<span<int>, int *, int>::value,
                 "span<int>(int*, int) is not constructible");
   static_assert(std::is_constructible<span<const int>, int *, int>::value,
@@ -73,39 +136,39 @@ TEST_CASE("iter, extent construction", "[PortsOfCall::span]") {
   }
 }
 
-TEST_CASE("Carr construction", "[PortsOfCall::span]") {
+template <class C, class E, std::size_t N = 3>
+constexpr auto array_construcible_correct() {
+  static_assert(std::is_nothrow_constructible<span<E>, C &>::value, "");
+  static_assert(!std::is_constructible<span<E>, const C &>::value, "");
+  static_assert(std::is_nothrow_constructible<span<const E>, C &>::value, "");
+  static_assert(std::is_nothrow_constructible<span<const E>, const C &>::value, "");
+
+  static_assert(std::is_nothrow_constructible<span<E, N>, C &>::value, "");
+  static_assert(!std::is_constructible<span<E, N>, const C &>::value, "");
+  static_assert(std::is_nothrow_constructible<span<const E, N>, C &>::value, "");
+  static_assert(std::is_nothrow_constructible<span<const E, N>, const C &>::value, "");
+}
+
+template <class E, class C, std::size_t N = 3>
+constexpr auto array_construcible_correct_oversized() {
+  constexpr auto M = N + 1;
+  static_assert(!std::is_constructible<span<int, M>, C &>::value, "");
+  static_assert(!std::is_constructible<span<int, M>, const C &>::value, "");
+
+  static_assert(!std::is_constructible<span<const int, M>, C &>::value, "");
+  static_assert(!std::is_constructible<span<const int, M>, const C &>::value, "");
+}
+
+TEST_CASE("span Carr construction", "[PortsOfCall::span]") {
   using int_array_t = int[3];
   using real_array_t = double[3];
 
-  static_assert(std::is_nothrow_constructible<span<int>, int_array_t &>::value, "");
-  static_assert(!std::is_constructible<span<int>, int_array_t const &>::value, "");
-  static_assert(!std::is_constructible<span<int>, real_array_t>::value, "");
+  array_construcible_correct<int_array_t, int>();
+  array_construcible_correct<real_array_t, double>();
 
-  static_assert(std::is_nothrow_constructible<span<const int>, int_array_t &>::value, "");
-  static_assert(
-      std::is_nothrow_constructible<span<const int>, int_array_t const &>::value, "");
-  static_assert(!std::is_constructible<span<const int>, real_array_t>::value, "");
+  array_construcible_correct_oversized<int_array_t, int>();
 
-  static_assert(std::is_nothrow_constructible<span<int, 3>, int_array_t &>::value, "");
-  static_assert(!std::is_constructible<span<int, 3>, int_array_t const &>::value, "");
-  static_assert(!std::is_constructible<span<int, 3>, real_array_t &>::value, "");
-
-  static_assert(std::is_nothrow_constructible<span<const int, 3>, int_array_t &>::value,
-                "");
-  static_assert(
-      std::is_nothrow_constructible<span<const int, 3>, int_array_t const &>::value, "");
-  static_assert(!std::is_constructible<span<const int, 3>, real_array_t>::value, "");
-
-  static_assert(!std::is_constructible<span<int, 42>, int_array_t &>::value, "");
-  static_assert(!std::is_constructible<span<int, 42>, int_array_t const &>::value, "");
-  static_assert(!std::is_constructible<span<int, 42>, real_array_t &>::value, "");
-
-  static_assert(!std::is_constructible<span<const int, 42>, int_array_t &>::value, "");
-  static_assert(!std::is_constructible<span<const int, 42>, int_array_t const &>::value,
-                "");
-  static_assert(!std::is_constructible<span<const int, 42>, real_array_t &>::value, "");
-
-  int arr[] = {0, 1, 2};
+  int_array_t arr = {0, 1, 2};
 
   SECTION("dynamic") {
     span<int> s{arr};
@@ -127,3 +190,260 @@ TEST_CASE("Carr construction", "[PortsOfCall::span]") {
     span_require(s, arr);
   }
 }
+
+TEST_CASE("span std::array construction", "[PortsOfCall::span]") {
+  using int_array_t = std::array<int, 3>;
+  using real_array_t = std::array<double, 3>;
+  using zero_array_t = std::array<int, 0>;
+
+  array_construcible_correct<int_array_t, int>();
+  array_construcible_correct<real_array_t, double>();
+  array_construcible_correct<zero_array_t, int, 0>();
+
+  array_construcible_correct_oversized<int_array_t, int>();
+  array_construcible_correct_oversized<real_array_t, int>();
+
+  int_array_t arr = {0, 1, 2};
+
+  SECTION("dynamic") {
+    span<int> s{arr};
+    span_require(s, arr.data());
+  }
+
+  SECTION("dynamic const") {
+    span<const int> s{arr};
+    span_require(s, arr.data());
+  }
+
+  SECTION("fixed") {
+    span<int, 3> s{arr};
+    span_require(s, arr.data());
+  }
+
+  SECTION("fixed const") {
+    span<const int, 3> s{arr};
+    span_require(s, arr.data());
+  }
+}
+
+template <class C, std::size_t N = 3>
+constexpr auto container_construcible_correct() {
+  using E = typename C::value_type;
+  static_assert(std::is_nothrow_constructible<span<E>, C &>::value, "");
+  static_assert(!std::is_constructible<span<E>, const C &>::value, "");
+  static_assert(std::is_nothrow_constructible<span<const E>, C &>::value, "");
+  static_assert(std::is_nothrow_constructible<span<const E>, const C &>::value, "");
+
+  static_assert(!std::is_constructible<span<E, N>, C &>::value, "");
+  static_assert(!std::is_constructible<span<E, N>, const C &>::value, "");
+  static_assert(!std::is_constructible<span<const E, N>, C &>::value, "");
+  static_assert(!std::is_constructible<span<const E, N>, const C &>::value, "");
+}
+
+TEST_CASE("span container construction", "[PortsOfCall::span]") {
+  using vec_t = std::vector<int>;
+
+  container_construcible_correct<vec_t>();
+  vec_t varr = {1, 2, 3};
+
+  SECTION("dynamic") {
+    span<int> s{varr};
+    span_require(s, varr.data());
+  }
+
+  SECTION("dynamic const") {
+    span<const int> s{varr};
+    span_require(s, varr.data());
+  }
+  // NB: fixed/fixed const is equivilant to std::array construction
+}
+
+TEST_CASE("span different size span construction", "PortsOfCall::span") {
+  using zero_span = span<int, 0>;
+  using zero_const_span = span<const int, 0>;
+
+  using big_span = span<int, 1000000>;
+  using big_const_span = span<const int, 1000000>;
+
+  using dynamic_span = span<int>;
+  using dynamic_const_span = span<const int>;
+
+  //
+  static_assert(std::is_trivially_copyable<zero_span>::value, "");
+  static_assert(std::is_trivially_move_constructible<zero_span>::value, "");
+
+  static_assert(!std::is_constructible<zero_span, big_span>::value, "");
+
+  static_assert(!std::is_constructible<zero_span, zero_const_span>::value, "");
+  static_assert(!std::is_constructible<zero_span, big_const_span>::value, "");
+  static_assert(!std::is_constructible<zero_span, dynamic_const_span>::value, "");
+
+  static_assert(std::is_nothrow_constructible<zero_span, dynamic_span>::value, "");
+  //
+  static_assert(std::is_trivially_copyable<big_span>::value, "");
+  static_assert(std::is_trivially_move_constructible<big_span>::value, "");
+
+  static_assert(!std::is_constructible<big_span, zero_span>::value, "");
+  static_assert(!std::is_constructible<big_span, zero_const_span>::value, "");
+  static_assert(!std::is_constructible<big_span, big_const_span>::value, "");
+  static_assert(!std::is_constructible<big_span, dynamic_const_span>::value, "");
+
+  static_assert(std::is_nothrow_constructible<big_span, dynamic_span>::value, "");
+  //
+  //
+  static_assert(std::is_trivially_copyable<zero_const_span>::value, "");
+  static_assert(std::is_trivially_move_constructible<zero_const_span>::value, "");
+  static_assert(!std::is_constructible<zero_const_span, big_span>::value, "");
+  static_assert(!std::is_constructible<zero_const_span, big_const_span>::value, "");
+  static_assert(std::is_nothrow_constructible<zero_const_span, zero_span>::value, "");
+
+  static_assert(std::is_nothrow_constructible<zero_const_span, dynamic_span>::value, "");
+  static_assert(std::is_nothrow_constructible<zero_const_span, dynamic_const_span>::value,
+                "");
+  //
+  static_assert(std::is_trivially_copyable<big_const_span>::value, "");
+  static_assert(std::is_trivially_move_constructible<big_const_span>::value, "");
+
+  static_assert(!std::is_constructible<big_const_span, zero_span>::value, "");
+  static_assert(!std::is_constructible<big_const_span, zero_const_span>::value, "");
+  static_assert(std::is_nothrow_constructible<big_const_span, big_span>::value, "");
+  static_assert(std::is_nothrow_constructible<big_const_span, dynamic_span>::value, "");
+  static_assert(std::is_nothrow_constructible<big_const_span, dynamic_const_span>::value,
+                "");
+  //
+  //
+  static_assert(std::is_trivially_copyable<dynamic_span>::value, "");
+  static_assert(std::is_trivially_move_constructible<dynamic_span>::value, "");
+
+  static_assert(!std::is_constructible<dynamic_span, big_const_span>::value, "");
+  static_assert(!std::is_constructible<dynamic_span, zero_const_span>::value, "");
+  static_assert(!std::is_constructible<dynamic_span, dynamic_const_span>::value, "");
+
+  static_assert(std::is_nothrow_constructible<dynamic_span, big_span>::value, "");
+  static_assert(std::is_nothrow_constructible<dynamic_span, zero_span>::value, "");
+
+  //
+  static_assert(std::is_trivially_copyable<dynamic_const_span>::value, "");
+  static_assert(std::is_trivially_move_constructible<dynamic_const_span>::value, "");
+
+  static_assert(std::is_nothrow_constructible<dynamic_const_span, zero_span>::value, "");
+  static_assert(std::is_nothrow_constructible<dynamic_const_span, zero_const_span>::value,
+                "");
+  static_assert(std::is_nothrow_constructible<dynamic_const_span, big_span>::value, "");
+  static_assert(std::is_nothrow_constructible<dynamic_const_span, big_const_span>::value,
+                "");
+  static_assert(std::is_nothrow_constructible<dynamic_const_span, dynamic_span>::value,
+                "");
+  constexpr zero_const_span s0{};
+  constexpr dynamic_const_span d{s0};
+
+  static_assert(d.size() == 0, "");
+  static_assert(d.data() == nullptr, "");
+  static_assert(d.begin() == d.end(), "");
+}
+
+TEST_CASE("span member subview operations", "[PortsOfCall::span]") {
+
+  int arr[] = {1, 2, 3, 4, 5};
+  span<int, 5> s{arr};
+
+  SECTION("first<N>") {
+    auto f = s.first<3>();
+
+    static_assert(std::is_same<decltype(f), span<int, 3>>::value, "");
+    span_require(f, arr);
+  }
+
+  SECTION("last<N>") {
+    auto l = s.last<3>();
+
+    static_assert(std::is_same<decltype(l), span<int, 3>>::value, "");
+    REQUIRE(l.size() == 3);
+    REQUIRE(l.data() == arr + 2);
+    REQUIRE(l.begin() == arr + 2);
+    REQUIRE(l.end() == std::end(arr));
+  }
+
+  SECTION("subspan<N>") {
+    auto ss = s.subspan<1, 2>();
+
+    static_assert(std::is_same<decltype(ss), span<int, 2>>::value, "");
+    REQUIRE(ss.size() == 2);
+    REQUIRE(ss.data() == arr + 1);
+    REQUIRE(ss.begin() == arr + 1);
+    REQUIRE(ss.end() == arr + 3);
+  }
+
+  SECTION("first(n)") {
+    auto f = s.first(3);
+
+    static_assert(std::is_same<decltype(f), span<int>>::value, "");
+    span_require(f, arr);
+  }
+
+  SECTION("last(n)") {
+    auto l = s.last(3);
+
+    static_assert(std::is_same<decltype(l), span<int>>::value, "");
+    REQUIRE(l.size() == 3);
+    REQUIRE(l.data() == arr + 2);
+    REQUIRE(l.begin() == arr + 2);
+    REQUIRE(l.end() == std::end(arr));
+  }
+
+  SECTION("subspan(n)") {
+    auto ss = s.subspan(1, 2);
+
+    static_assert(std::is_same<decltype(ss), span<int>>::value, "");
+    REQUIRE(ss.size() == 2);
+    REQUIRE(ss.data() == arr + 1);
+    REQUIRE(ss.begin() == arr + 1);
+    REQUIRE(ss.end() == arr + 3);
+  }
+}
+
+TEST_CASE("span observers", "[PortsOfCall::span]") {
+  constexpr span<int, 0> empty{};
+  static_assert(empty.size() == 0, "");
+  static_assert(empty.empty(), "");
+
+  constexpr int arr[] = {1, 2, 3};
+  static_assert(span<const int>{arr}.size() == 3, "");
+  static_assert(!span<const int>{arr}.empty(), "");
+}
+
+TEST_CASE("span element access", "[PortsOfCall::span]") {
+  constexpr int arr[] = {1, 2, 3};
+  span<const int> s{arr};
+
+  REQUIRE(s[0] == arr[0]);
+  REQUIRE(s[1] == arr[1]);
+  REQUIRE(s[2] == arr[2]);
+}
+
+// adopted from https://en.cppreference.com/w/cpp/container/span
+TEST_CASE("span typical", "[PortsOfCall::span]") {
+  constexpr int a[]{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr int b[]{8, 7, 6};
+  constexpr static std::size_t width{6};
+
+  constexpr int res[][width] = {
+      {0, 1, 2, 3, 4, 5}, {1, 2, 3, 4, 5, 6}, {2, 3, 4, 5, 6, 7}, {3, 4, 5, 6, 7, 8}};
+
+  for (std::size_t offset{};; ++offset)
+    if (auto s = detail::slide(span{a}, offset, width); !s.empty())
+      REQUIRE(detail::equal(s.begin(), s.end(), std::begin(res[offset])));
+    else
+      break;
+
+  static_assert("" && detail::starts_with(span{a}, span{a, 4}) &&
+                detail::starts_with(span{a + 1, 4}, span{a + 1, 3}) &&
+                !detail::starts_with(span{a}, span{b}) &&
+                !detail::starts_with(span{a, 8}, span{a + 1, 3}) &&
+                detail::ends_with(span{a}, span{a + 6, 3}) &&
+                !detail::ends_with(span{a}, span{a + 6, 2}) &&
+                detail::contains(span{a}, span{a + 1, 4}) &&
+                !detail::contains(span{a, 8}, span{a, 9}));
+}
+
+} // namespace test

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -1,12 +1,25 @@
 #include "ports-of-call/span.hpp"
 #include <type_traits>
 
+// ========================================================================================
+// © (or copyright) 2019-2024. Triad National Security, LLC. All rights
+// reserved.  This program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which is
+// operated by Triad National Security, LLC for the U.S.  Department of
+// Energy/National Nuclear Security Administration. All rights in the
+// program are reserved by Triad National Security, LLC, and the
+// U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others acting
+// on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute
+// copies to the public, perform publicly and display publicly, and to
+// permit others to do so.
+// ========================================================================================
+
 #ifndef CATCH_CONFIG_FAST_COMPILE
 #define CATCH_CONFIG_FAST_COMPILE
 #include <catch2/catch_test_macros.hpp>
 #endif
-
-#include <iostream>
 
 namespace test {
 

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -1,0 +1,71 @@
+#include "ports-of-call/span.hh"
+#include <type_traits>
+
+#ifndef CATCH_CONFIG_FAST_COMPILE
+#define CATCH_CONFIG_FAST_COMPILE
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+#include <iostream>
+
+#define FIXED 10
+
+using namespace PortsOfCall::span;
+
+template <class S, class I, auto N = 3>
+auto span_require(S &&s, I &&i) {
+  REQUIRE(s.size() == N);
+  REQUIRE(s.data() == i);
+  REQUIRE(s.begin() == std::begin(i));
+  REQUIRE(s.end() == std::end(i));
+}
+
+TEST_CASE("default construction", "[PortsOfCall::span]") {
+  static_assert(std::is_nothrow_default_constructible<span<int>>::value, "");
+  static_assert(std::is_nothrow_constructible<span<int, 0>>::value, "");
+
+  static_assert(!std::is_nothrow_constructible<span<int, FIXED>>::value, "");
+
+  SECTION("dynamic size") {
+    constexpr span<int> s{};
+    static_assert(s.size() == 0, "default constructed dynamic size span has size != 0");
+    static_assert(s.data() == 0,
+                  "default constructed dynamic size span has data != nullptr");
+    static_assert(s.begin() == s.end(),
+                  "default constructed dynamic size span has begin != end");
+  }
+
+  SECTION("fixed size") {
+    constexpr span<int, 0> s{};
+    static_assert(s.size() == 0, "default constructed fixed size span has size != 0");
+    static_assert(s.data() == 0,
+                  "default constructed fixed size span has data != nullptr");
+    static_assert(s.begin() == s.end(),
+                  "default constructed fixed size span has begin != end");
+  }
+}
+
+TEST_CASE("iter, extent construction", "[PortsOfCall::span]") {
+  static_assert(std::is_constructible<span<int>, int *, int>::value,
+                "span<int>(int*, int) is not constructible");
+  static_assert(std::is_constructible<span<const int>, int *, int>::value,
+                "span<const int>(int*, int) is not constructible");
+  static_assert(std::is_constructible<span<const int>, const int *, int>::value,
+                "span<const int>(const int*, int) is not constructible");
+
+  static_assert(std::is_constructible<span<int, FIXED>, int *, int>::value,
+                "span<int, FIXED>(int*, int) is not constructible");
+  static_assert(std::is_constructible<span<const int, FIXED>, int *, int>::value,
+                "span<const int, FIXED>(int*, int) is not constructible");
+  static_assert(std::is_constructible<span<const int, FIXED>, const int *, int>::value,
+                "span<const int, FIXED>(const int*, int) is not constructible");
+
+  int arr[] = {0, 1, 2};
+
+  span<int, 3> s(arr, 3);
+
+  SECTION("dynamic") {
+    span<int> s{arr, arr + 3};
+    span_require(s, arr);
+  }
+}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

A `span` implementation that (in broad terms) follows C++20. See https://en.cppreference.com/w/cpp/container/span for more information on this.

This replaces the PR provided by @BrendanKKrueger (https://github.com/lanl/ports-of-call/pull/47) in giving a more complete `span`.

@jonahm-LANL @dholladay00 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

TODO:
- [x] Implement Testing
- [x] Cleaner comments

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
