### PR TITLE
Fix non-constexpr math function

### DIFF
--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -1,7 +1,7 @@
-#include "ports-of-call/span.hpp"
 #include "ports-of-call/portability.hpp"
-#include <type_traits>
+#include "ports-of-call/span.hpp"
 #include <cmath>
+#include <type_traits>
 
 // ========================================================================================
 // © (or copyright) 2019-2024. Triad National Security, LLC. All rights
@@ -564,19 +564,17 @@ TEST_CASE("span portability", "[PortsOfCall::span]") {
   constexpr const std::size_t Nb = N * sizeof(Real);
   constexpr const Real tol = 1.0E-8;
 
-  constexpr const Real pi = std::acos(-1);
+  constexpr const Real pi = 3.141592653589793238462643383279502884;
 
   constexpr Real d_gp = 2. * pi / static_cast<Real>(N);
 
   std::vector<Real> h_gp(N);
-  for(auto i = 0; i < N; ++i)
-  {
+  for (auto i = 0; i < N; ++i) {
     h_gp[i] = -pi + static_cast<Real>(i) * d_gp;
   }
 
+  Real *p_a = (Real *)PORTABLE_MALLOC(Nb);
 
-  Real *p_a = (Real*) PORTABLE_MALLOC(Nb);
-  
   // device span, host span
   span d_s(p_a, N);
   span h_s(h_gp);
@@ -586,11 +584,13 @@ TEST_CASE("span portability", "[PortsOfCall::span]") {
 
   // integrate cos x dx over [-pi,pi]
   Real res_sum{0.0};
-  portableReduce( "integrate", 0, N, PORTABLE_LAMBDA(const int i, Real& rsum){ rsum += (std::cos(d_s[i])*d_gp) ;}, res_sum);
+  portableReduce(
+      "integrate", 0, N,
+      PORTABLE_LAMBDA(const int i, Real &rsum) { rsum += (std::cos(d_s[i]) * d_gp); },
+      res_sum);
 
   // require sum < tol
-  REQUIRE(std::abs(res_sum) < tol); 
-
+  REQUIRE(std::abs(res_sum) < tol);
 
   PORTABLE_FREE(p_a);
 }

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -564,7 +564,7 @@ TEST_CASE("span portability", "[PortsOfCall::span]") {
   constexpr const std::size_t Nb = N * sizeof(Real);
   constexpr const Real tol = 1.0E-8;
 
-  constexpr const Real pi = 3.141592653589793238462643383279502884;
+  constexpr const Real pi = M_PI;
 
   constexpr Real d_gp = 2. * pi / static_cast<Real>(N);
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

To fix #63 

Replaced "in-line" pi calculation with explicit decimal value.

@rbberger @jonahm-LANL 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
