### PR TITLE
Add snprintf. Hide sprintf as fancy snprintf

### DIFF
--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -127,7 +127,7 @@ inline std::size_t strlen(Head h, Tail... tail) {
       }
     }
   } else {
-    i = 20; // some big number to account for things like %.14e
+    i = 100; // some big number to account for things like %.14e
   }
   if constexpr (sizeof...(Tail) > 0) {
     i += strlen(tail...);

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -117,7 +117,7 @@ PORTABLE_INLINE_FUNCTION void printf(char const *const format, Ts... ts) {
 }
 // Variadic strlen
 template <typename Head, typename... Tail>
-inline std::size_t strlen(Head h, Tail... tail) {
+PORTABLE_INLINE_FUNCTION std::size_t strlen(Head h, Tail... tail) {
   constexpr std::size_t MAX_I = 4096;
   std::size_t i = 0;
   if constexpr (std::is_convertible_v<Head, std::string_view>) {

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -115,39 +115,10 @@ PORTABLE_INLINE_FUNCTION void printf(char const *const format, Ts... ts) {
 #endif // __HIPCC__
   return;
 }
-// Variadic strlen
-template <typename Head, typename... Tail>
-PORTABLE_INLINE_FUNCTION std::size_t strlen(Head h, Tail... tail) {
-  constexpr std::size_t MAX_I = 4096;
-  std::size_t i = 0;
-  if constexpr (std::is_convertible_v<Head, std::string_view>) {
-    // don't want a non-terminating loop if there's now null
-    // character.
-    for (i = 0; i < MAX_I; ++i) {
-      if (h[i] == '\0') {
-        break;
-      }
-    }
-  } else {
-    i = 100; // some big number to account for things like %.14e
-  }
-  if constexpr (sizeof...(Tail) > 0) {
-    i += strlen(tail...);
-  }
-  return i;
-}
 template <typename... Ts>
 PORTABLE_INLINE_FUNCTION void snprintf(char *target, std::size_t size,
                                        char const *const format, Ts... ts) {
 #ifndef __HIPCC__
-  std::snprintf(target, size, format, ts...);
-#endif // __HIPCC__
-  return;
-}
-template <typename... Ts>
-PORTABLE_INLINE_FUNCTION void sprintf(char *target, char const *const format, Ts... ts) {
-#ifndef __HIPCC__
-  std::size_t size = PortsOfCall::strlen(format, ts...);
   std::snprintf(target, size, format, ts...);
 #endif // __HIPCC__
   return;

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -113,16 +113,37 @@ PORTABLE_INLINE_FUNCTION void printf(char const *const format, Ts... ts) {
 #endif // __HIPCC__
   return;
 }
+// Variadic strlen
 template <typename... Ts>
-PORTABLE_INLINE_FUNCTION void snprintf(char *target, std::size_t size, char const *const format, Ts... ts) {
+inline std::size_t strlen(char const *const str, Ts... ts) {
+  constexpr size_t MAX_I = 4096;
+  std::size_t i;
+  for (i = 0; i < MAX_I; ++i) {
+    if (str[i] == '\0') {
+      break;
+    }
+  }
+  if constexpr (sizeof...(Ts) > 0) {
+    i += mystrlen(ts...);
+  }
+  return i;
+}
+template <typename... Ts>
+PORTABLE_INLINE_FUNCTION void snprintf(char *target, std::size_t size,
+                                       char const *const format, Ts... ts) {
 #ifndef __HIPCC__
   std::snprintf(target, size, format, ts...);
 #endif // __HIPCC__
   return;
 }
 template <typename... Ts>
-PORTABLE_INLINE_FUNCTION void sprintf(char *target, char const *const format, Ts... ts) {
-  PortsOfCall::snprintf(target, PORTABLE_MAX_NUM_CHAR, format, ts...);
+PORTABLE_INLINE_FUNCTION void sprintf(char *target, std::size_t size,
+                                      char const *const format, Ts... ts) {
+#ifndef __HIPCC__
+  std::size_t size = PortsOfCall::strlen(format, ts...);
+  std::snprintf(target, size, format, ts...);
+#endif // __HIPCC__
+  return;
 }
 } // namespace PortsOfCall
 

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -118,9 +118,11 @@ PORTABLE_INLINE_FUNCTION void printf(char const *const format, Ts... ts) {
 // Variadic strlen
 template <typename Head, typename... Tail>
 inline std::size_t strlen(Head h, Tail... tail) {
-  constexpr size_t MAX_I = 4096;
+  constexpr std::size_t MAX_I = 4096;
   std::size_t i = 0;
   if constexpr (std::is_convertible_v<Head, std::string_view>) {
+    // don't want a non-terminating loop if there's now null
+    // character.
     for (i = 0; i < MAX_I; ++i) {
       if (h[i] == '\0') {
         break;

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -104,6 +104,7 @@ constexpr bool EXECUTION_IS_HOST{false};
 constexpr bool EXECUTION_IS_HOST{true};
 #endif
 // portable printf
+#define PORTABLE_MAX_NUM_CHAR (2048)
 template <typename... Ts>
 PORTABLE_INLINE_FUNCTION void printf(char const *const format, Ts... ts) {
   // disable for hip
@@ -111,6 +112,17 @@ PORTABLE_INLINE_FUNCTION void printf(char const *const format, Ts... ts) {
   std::printf(format, ts...);
 #endif // __HIPCC__
   return;
+}
+template <typename... Ts>
+PORTABLE_INLINE_FUNCTION void snprintf(char *target, std::size_t size, char const *const format, Ts... ts) {
+#ifndef __HIPCC__
+  std::snprintf(target, size, format, ts...);
+#endif // __HIPCC__
+  return;
+}
+template <typename... Ts>
+PORTABLE_INLINE_FUNCTION void sprintf(char *target, char const *const format, Ts... ts) {
+  PortsOfCall::snprintf(target, PORTABLE_MAX_NUM_CHAR, format, ts...);
 }
 } // namespace PortsOfCall
 

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -49,8 +49,7 @@
   PortsOfCall::ErrorChecking::warn(message, __FILE__, __LINE__)
 
 // Fills a char* array output with an error message
-// with file name and line number. Note there is no bounds checking
-// so make sure you allocate enough memory.
+// with file name and line number.
 #define PORTABLE_ERROR_MESSAGE(message, output, maxsize)                                 \
   PortsOfCall::ErrorChecking::error_msg(message, maxsize, __FILE__, __LINE__, output)
 

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -184,9 +184,10 @@ inline void warn(std::string const &message, const char *const filename,
 PORTABLE_INLINE_FUNCTION
 void error_msg(const char *const input_message, const char *const filename,
                int const linenumber, char *output_message) {
-  std::sprintf(output_message,
-               "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
-               input_message, filename, linenumber);
+  PortsOfCall::sprintf(
+      output_message,
+      "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+      input_message, filename, linenumber);
 }
 inline void error_msg(std::stringstream const &input_message, const char *const filename,
                       int const linenumber, char *output_message) {

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -51,8 +51,8 @@
 // Fills a char* array output with an error message
 // with file name and line number. Note there is no bounds checking
 // so make sure you allocate enough memory.
-#define PORTABLE_ERROR_MESSAGE(message, output)                                          \
-  PortsOfCall::ErrorChecking::error_msg(message, __FILE__, __LINE__, output)
+#define PORTABLE_ERROR_MESSAGE(message, output, maxsize)                                 \
+  PortsOfCall::ErrorChecking::error_msg(message, maxsize, __FILE__, __LINE__, output)
 
 // Aborts the program with an error message with file and line number.
 // if PORTABILITY_STRATEGY_NONE is enabled, then this throws a C++
@@ -182,20 +182,22 @@ inline void warn(std::string const &message, const char *const filename,
 // Fills the output_message char* array with an error message with
 // filename and line number.
 PORTABLE_INLINE_FUNCTION
-void error_msg(const char *const input_message, const char *const filename,
-               int const linenumber, char *output_message) {
-  PortsOfCall::sprintf(
-      output_message,
+void error_msg(const char *const input_message, const std::size_t maxsize,
+               const char *const filename, int const linenumber, char *output_message) {
+  PortsOfCall::snprintf(
+      output_message, maxsize,
       "### ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
       input_message, filename, linenumber);
 }
-inline void error_msg(std::stringstream const &input_message, const char *const filename,
-                      int const linenumber, char *output_message) {
-  error_msg(input_message.str().c_str(), filename, linenumber, output_message);
+inline void error_msg(std::stringstream const &input_message, const std::size_t maxsize,
+                      const char *const filename, int const linenumber,
+                      char *output_message) {
+  error_msg(input_message.str().c_str(), maxsize, filename, linenumber, output_message);
 }
-inline void error_msg(std::string const &input_message, const char *const filename,
-                      int const linenumber, char *output_message) {
-  error_msg(input_message.c_str(), filename, linenumber, output_message);
+inline void error_msg(std::string const &input_message, const std::size_t maxsize,
+                      const char *const filename, int const linenumber,
+                      char *output_message) {
+  error_msg(input_message.c_str(), maxsize, filename, linenumber, output_message);
 }
 
 } // namespace ErrorChecking

--- a/ports-of-call/portable_errors.hpp
+++ b/ports-of-call/portable_errors.hpp
@@ -180,7 +180,7 @@ inline void warn(std::string const &message, const char *const filename,
 }
 
 // Fills the output_message char* array with an error message with
-// filename and line number. Beware! No bounds checking!
+// filename and line number.
 PORTABLE_INLINE_FUNCTION
 void error_msg(const char *const input_message, const char *const filename,
                int const linenumber, char *output_message) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Apparently compilers don't like us using `sprintf` because of the risk of writing arbitrary bits to memory. This switches `portable_errors` to using `snprintf` for error messages.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
