### PR TITLE
Fix CMake install missing header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,15 @@
-#------------------------------------------------------------------------------#
-# © 2021-2022. Triad National Security, LLC. All rights reserved.  This
-# program was produced under U.S. Government contract 89233218CNA000001
-# for Los Alamos National Laboratory (LANL), which is operated by Triad
-# National Security, LLC for the U.S.  Department of Energy/National
-# Nuclear Security Administration. All rights in the program are
-# reserved by Triad National Security, LLC, and the U.S. Department of
-# Energy/National Nuclear Security Administration. The Government is
-# granted for itself and others acting on its behalf a nonexclusive,
-# paid-up, irrevocable worldwide license in this material to reproduce,
-# prepare derivative works, distribute copies to the public, perform
+# ------------------------------------------------------------------------------#
+# © 2021-2022. Triad National Security, LLC. All rights reserved.  This program
+# was produced under U.S. Government contract 89233218CNA000001 for Los Alamos
+# National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S.  Department of Energy/National Nuclear Security Administration.
+# All rights in the program are reserved by Triad National Security, LLC, and
+# the U.S. Department of Energy/National Nuclear Security Administration. The
+# Government is granted for itself and others acting on its behalf a
+# nonexclusive, paid-up, irrevocable worldwide license in this material to
+# reproduce, prepare derivative works, distribute copies to the public, perform
 # publicly and display publicly, and to permit others to do so.
-#------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------#
 
 cmake_minimum_required(VERSION 3.14)
 
@@ -26,18 +25,21 @@ project(ports-of-call VERSION ${PORTS_OF_CALL_VERSION})
 
 # Don't allow in-source builds
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
-  message(FATAL_ERROR
-    "You cannot build in a source directory (or any directory with a CMakeLists.txt file). "
-    "Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
+  message(
+    FATAL_ERROR
+      "You cannot build in a source directory (or any directory with a CMakeLists.txt file). "
+      "Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles."
+  )
 endif()
 
-option (PORTS_OF_CALL_BUILD_TESTING "Test the current installation" OFF)
+option(PORTS_OF_CALL_BUILD_TESTING "Test the current installation" OFF)
 # off by default but possible to turn on
-if (PORTS_OF_CALL_BUILD_TESTING)
-  set(PORTS_OF_CALL_TEST_PORTABILITY_STRATEGY "None" CACHE STRING
-    "Portability strategy used by tests")
+if(PORTS_OF_CALL_BUILD_TESTING)
+  set(PORTS_OF_CALL_TEST_PORTABILITY_STRATEGY
+      "None"
+      CACHE STRING "Portability strategy used by tests")
   set_property(CACHE PORTS_OF_CALL_TEST_PORTABILITY_STRATEGY
-    PROPERTY STRINGS None Cuda Kokkos)
+               PROPERTY STRINGS None Cuda Kokkos)
 endif()
 
 # CONFIGURATION LOGIC
@@ -47,9 +49,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 # TARGET CONFIGURATION
 # ----------------------------------------
 
-# Define library
-# use a string variable to ease derived variable naming
-# NOTE: this gets used for directory names
+# Define library use a string variable to ease derived variable naming NOTE:
+# this gets used for directory names
 set(POCLIB "ports-of-call")
 # Pure-header library, so just use interface
 add_library(${POCLIB} INTERFACE)
@@ -59,18 +60,12 @@ add_library(${POCLIB}::${POCLIB} ALIAS ${POCLIB})
 # make cache variables for install destinations
 include(GNUInstallDirs)
 
-# Enables
-# #include <ports-of-call/portability.hpp>
-target_include_directories(${POCLIB}
-  INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
+# Enables #include <ports-of-call/portability.hpp>
+target_include_directories(
+  ${POCLIB} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-target_compile_features(${POCLIB}
-  INTERFACE
-    cxx_std_17
-)
+target_compile_features(${POCLIB} INTERFACE cxx_std_17)
 
 # TESTING
 # ----------------------------------------
@@ -90,15 +85,15 @@ include(Format)
 # package config file
 include(CMakePackageConfigHelpers)
 
-
 # Coordinate external CMake interface (EXPORT) with targets
-install(TARGETS ${POCLIB}
+install(
+  TARGETS ${POCLIB}
   EXPORT ${POCLIB}Targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+  INCLUDES
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${POCLIB}Config.cmake.in
@@ -111,40 +106,33 @@ configure_package_config_file(
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/${POCLIB}ConfigVersion.cmake
   VERSION ${PORTS_OF_CALL_VERSION}
-  COMPATIBILITY SameMajorVersion
-)
+  COMPATIBILITY SameMajorVersion)
 
 # Install the cmake configuration files
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${POCLIB}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${POCLIB}ConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${POCLIB}
-)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${POCLIB})
 
 # Install the source header files
-install(
-  FILES "${CMAKE_CURRENT_SOURCE_DIR}/ports-of-call/portability.hpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/ports-of-call/portable_arrays.hpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/ports-of-call/portable_errors.hpp"
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${POCLIB}
-)
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/${POCLIB}"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-# Install the export target. This will define the CMake target
-# for external projects when used with `find_package`
+# Install the export target. This will define the CMake target for external
+# projects when used with `find_package`
 install(
   EXPORT ${POCLIB}Targets
   NAMESPACE ${POCLIB}::
   FILE ${POCLIB}Targets.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${POCLIB}
-)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${POCLIB})
 
 # NOTE: This config will not be relocatable!
 export(
-  TARGETS ${POCLIB} 
+  TARGETS ${POCLIB}
   NAMESPACE ${POCLIB}::
   FILE "${CMAKE_CURRENT_BINARY_DIR}/${POCLIB}Targets.cmake")
 
-
-# Configuration summary ---------------------------------------------------------------------------
+# Configuration summary
+# ---------------------------------------------------------------------------
 
 include(config_summary)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,8 +19,8 @@ if(NOT TARGET Catch2::Catch2)
     FetchContent_Declare(
       Catch2
       GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-      # or later is fine too
-      GIT_TAG v3.0.1)
+      # JMM: update to 3.7.1 12/18/24 for Ubuntu 24.04
+      GIT_TAG v3.7.1)
     FetchContent_MakeAvailable(Catch2)
     list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
   endif()


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Header files have been added that the CMake install has not kept track of. This changes the install from a "per-file" to a "directory", so that future headers will also be included.

Install before

```bash
$> cmake --install .
-- Install configuration: ""
-- Installing: <prefix>/lib/cmake/ports-of-call/ports-of-callConfig.cmake
-- Installing: <prefix>/lib/cmake/ports-of-call/ports-of-callConfigVersion.cmake
-- Installing: <prefix>/include/ports-of-call/portability.hpp
-- Installing: <prefix>/include/ports-of-call/portable_arrays.hpp
-- Installing: <prefix>/include/ports-of-call/portable_errors.hpp
-- Installing: <prefix>/lib/cmake/ports-of-call/ports-of-callTargets.cmake
```

With PR:

```bash
$> cmake --install .
-- Install configuration: ""
-- Installing: <prefix>/lib/cmake/ports-of-call/ports-of-callConfig.cmake
-- Installing: <prefix>/lib/cmake/ports-of-call/ports-of-callConfigVersion.cmake
-- Installing: <prefix>/include/ports-of-call
-- Installing: <prefix>/include/ports-of-call/portability.hpp
-- Installing: <prefix>/include/ports-of-call/span.hpp
-- Installing: <prefix>/include/ports-of-call/portable_errors.hpp
-- Installing: <prefix>/include/ports-of-call/robust_utils.hpp
-- Installing: <prefix>/include/ports-of-call/array.hpp
-- Installing: <prefix>/include/ports-of-call/portable_arrays.hpp
-- Installing: <prefix>/include/ports-of-call/static_vector.hpp
-- Installing: <prefix>/lib/cmake/ports-of-call/ports-of-callTargets.cmake
```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [x] Install test passes.
- [x] Docs build.
- [x] If preparing for a new release, update the version in cmake.
