### PR TITLE
Prepare for Spack v1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.14)
 
 # define project and version
 set(PORTS_OF_CALL_VERSION 1.7.1)
-project(ports-of-call VERSION ${PORTS_OF_CALL_VERSION})
+project(ports-of-call VERSION ${PORTS_OF_CALL_VERSION} LANGUAGES CXX)
 
 # CMAKE WARMUP
 # ----------------------------------------

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -52,6 +52,8 @@ class PortsOfCall(CMakePackage):
         when="@1.6.1: +test",
     )
 
+    depends_on("cxx", type="build")
+
     depends_on("cmake@3.12:")
     depends_on("catch2@3.0.1:", when="+test")
     depends_on("kokkos", when="+test test_portability_strategy=Kokkos")


### PR DESCRIPTION
## PR Summary

These changes are backwards compatible all the way to v0.23. Since Singularity-EOS already has them, we should just bring this library up-to-date. There is more Spack related changes incoming due to the Package API v2 changes, but that will be its own PR.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
