### PR TITLE
spack: add missing C dependency for older versions

### DIFF
--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -52,6 +52,7 @@ class PortsOfCall(CMakePackage):
         when="@1.6.1: +test",
     )
 
+    depends_on("c", type="build", when="@:1.7.1")
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.12:")


### PR DESCRIPTION
## PR Summary

Add correct compiler dependency in case someone wants to install an older version with Spack 1.0.0.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
