### PR TITLE
spack: remove language dependencies in v1

### DIFF
--- a/spack-repo/v1/packages/ports-of-call/package.py
+++ b/spack-repo/v1/packages/ports-of-call/package.py
@@ -52,9 +52,6 @@ class PortsOfCall(CMakePackage):
         when="@1.6.1: +test",
     )
 
-    depends_on("c", type="build", when="@:1.7.1")
-    depends_on("cxx", type="build")
-
     depends_on("cmake@3.12:")
     depends_on("catch2@3.0.1:", when="+test")
     depends_on("kokkos", when="+test test_portability_strategy=Kokkos")


### PR DESCRIPTION
## PR Summary

This increases the spack package compatibility for even older versions.

Language dependencies were backported down to v0.21.3, even though they didn't have any meaningful effect before v1.0.0. Older version would however report an error.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
