### PR TITLE
Change CMake install location to be relative to ports-of-call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${POCLIB}Config.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${POCLIB})
 
 # Install the source header files
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/${POCLIB}"
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/${POCLIB}"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 # Install the export target. This will define the CMake target for external


### PR DESCRIPTION

<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

* Change `CMAKE_SOURCE_DIR` to `PROJECT_SOURCE_DIR` to get a path relative to ports-of-call CMake project instead of relative to top level CMake source (enables installs where ports of call is fetched and built by cmake). In our project ports-of-call thought its headers were located in our source path instead of the fetched ports-of-call source tree. This should allow installations where ports-of-call is fetched and built as a dependency.

* Old CMake variable: `CMAKE_SOURCE_DIR`: https://cmake.org/cmake/help/latest/variable/CMAKE_SOURCE_DIR.html
* New CMake variable: `PROJECT_SOURCE_DIR`: https://cmake.org/cmake/help/latest/variable/PROJECT_SOURCE_DIR.html

## PR Checklist

- [ ] Any changes to code are appropriately documented.
- [ ] Code is formatted.
- [ ] Install test passes.
- [ ] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
