### PR TITLE
Expose execution space in portable dispatch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,5 @@ detail.  Why is this change required?  What problem does it solve?-->
 - [ ] Install test passes.
 - [ ] Docs build.
 - [ ] If preparing for a new release, update the version in cmake.
+- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
+- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

--- a/doc/sphinx/src/developing.rst
+++ b/doc/sphinx/src/developing.rst
@@ -29,6 +29,26 @@ internal tests will not be run automatically. So when the code is
 ready for merge, you must ask a project maintainer to trigger the
 remaining tests for you.
 
+AI-assisted coding
+-------------------
+
+``ports-of-call`` requires that if AI was used to assist in code
+generation, a disclaimer must be made in a comment in the relevant
+file. Also if agentic AI was used, please have your agent dump a
+"proposed plan" markdown file in the ``plan_histories`` file. This
+provides an LLM-readable history of machine-generated changes and
+helps disentangle human-made choices from machine-made ones.
+
+If you submit code to ``ports-of-call`` you own that code and you are
+responsible for understanding it. If code is submitted that the author
+does not understand, the author will be asked to resubmit changeset
+that they understand.
+
+Finally, please be cognizant of reviewer time and effort. Agentic AI
+can create changesets much faster than a human can review them. When
+possible, please break up large changes and refactors into
+human-parse-able chunks.
+
 Getting the right version of clang-format
 ------------------------------------------
 

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -449,3 +449,7 @@ not be thrown on device.
 
 .. _`mpark variant`:  https://github.com/mpark/variant
 .. _`variant`: https://en.cppreference.com/w/cpp/utility/variant.html
+
+.. note::
+
+  This file was generated in part with generative AI.

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -39,7 +39,7 @@ portability.hpp
 functions. Also provides loop abstractions that can be leveraged by a
 code. These loop abstractions are of the form:
 
-.. cpp:function:: void portableFor(const char *name, int start, int stop, Function Function)
+.. cpp:function:: template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function> void portableFor(const char *name, int start, int stop, Function function)
 
 where ``Function`` is a template parameter and should be set to a
 functor that takes one index, e.g., an index in an array. For example:
@@ -51,12 +51,27 @@ functor that takes one index, e.g., an index in an array. For example:
       printf("hello from thread %d\n", i);
   });
 
+The optional template parameter ``E`` selects the execution space to
+launch on. The default is ``PortsOfCall::Exec::Device``, which preserves
+the historical behavior. Under Kokkos, ``PortsOfCall::Exec::Device``
+maps to ``Kokkos::DefaultExecutionSpace`` and ``PortsOfCall::Exec::Host``
+maps to ``Kokkos::DefaultHostExecutionSpace``.
+
+For example, to force a loop onto the host execution space:
+
+.. code-block:: cpp
+
+  portableFor<PortsOfCall::Exec::Host>("ExampleHost", 0, 5,
+    PORTABLE_LAMBDA(int i) {
+      printf("hello from host thread %d\n", i);
+  });
+
 ``start`` is inclusive, ``stop`` is exclusive. Up to five-dimensional
 ``portableFor`` loops are available. For example:
 
 .. code-block:: cpp
 
-  template <typename Function>
+  template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
   void portableFor(const char *name, int startb, int stopb, int starta, int stopa,
     int startz, int stopz, int starty, int stopy, int startx,
     int stopx, Function function) {
@@ -66,7 +81,7 @@ limited. The syntax is:
 
 .. code-block::
 
-  template <typename Function, typename T>
+  template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
   void portableReduce(const char *name, int starta, int stopa, int startz,
     int stopz, int starty, int stopy, int startx, int stopx,
     Function function, T &reduced) {
@@ -75,6 +90,24 @@ where ``Function`` now takes as many indices are required and
 ``reduced`` as arguments. Note that a ``portableReduce()`` is blocking (i.e. a
 device synchronization step is performed) while `portableFor()` may not be,
 possibly requiring a ``PORTABLE_FENCE`` to avoid any race conditions.
+
+As with ``portableFor``, the optional ``E`` template parameter can be
+used to select host or device execution explicitly. For example:
+
+.. code-block:: cpp
+
+  int sum = 0;
+  portableReduce<PortsOfCall::Exec::Host>(
+    "HostReduce", 0, 5,
+    PORTABLE_LAMBDA(int i, int &local_sum) {
+      local_sum += i;
+    }, sum);
+
+When selecting ``PortsOfCall::Exec::Host``, the lambda or functor and
+the memory it touches must be valid on host. When selecting
+``PortsOfCall::Exec::Device``, device-accessible storage should be used,
+for example memory returned by ``PORTABLE_MALLOC()`` under device
+backends.
 
 Also provided are host to device and device to host memory transfers of the form:
 

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -21,8 +21,7 @@ To include Ports of Call in your project, simply include the directory
 5. ``_WITH_KOKKOS_``: Defined if Kokkos is enabled.
 6. ``_WITH_CUDA_``: Defined when Cuda is enabled
 7. ``Real``: a typedef to double (default) or float (if you define ``SINGLE_PRECISION_ENABLED``)
-8. ``PORTABLE_MALLOC()``, ``PORTABLE_FREE()``: A wrapper for kokkos_malloc or cudaMalloc, or raw malloc and equivalent free.
-9. ``PORTABLE_FENCE()``: A wrapper for ``kokkos::fence`` or ``cudaDeviceSynchronize()``
+8. ``PORTABLE_FENCE()``: A wrapper for ``kokkos::fence`` or ``cudaDeviceSynchronize()``
 
 At compile time, you define
 ``PORTABILITY_STRATEGY_{KOKKOS,CUDA,NONE}`` (if you don't define it,
@@ -36,8 +35,22 @@ portability.hpp
 ^^^^^^^^^^^^^^^^
 
 ``portability.hpp`` provides the above-mentioned macros for decorating
-functions. Also provides loop abstractions that can be leveraged by a
-code. These loop abstractions are of the form:
+functions. It also provides several additional abstractions:
+
+.. cpp:function:: PortsOfCall::portableMalloc(Exec e, std::size_t size_bytes)
+
+and
+
+.. cpp:function:: template<typename T> PortsOfCall::portableFree(Exec e, T *ptr)
+
+allocate and free memory respectively, where the enum ``Exec`` may be
+either ``PortsOfCall::Exec::Host`` or
+``PortsOfCall::Exec::Device``. The ``Exec`` argument is
+optional. These are also the backend for macros ``PORTABLE_MALLOC``
+and ``PORTABLE_FREE``.
+
+``portability.hpp`` also provides loop abstractions that can be
+leveraged by a code. These loop abstractions are of the form:
 
 .. cpp:function:: template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function> void portableFor(const char *name, int start, int stop, Function function)
 
@@ -52,12 +65,8 @@ functor that takes one index, e.g., an index in an array. For example:
   });
 
 The optional template parameter ``E`` selects the execution space to
-launch on. The default is ``PortsOfCall::Exec::Device``, which preserves
-the historical behavior. Under Kokkos, ``PortsOfCall::Exec::Device``
-maps to ``Kokkos::DefaultExecutionSpace`` and ``PortsOfCall::Exec::Host``
-maps to ``Kokkos::DefaultHostExecutionSpace``.
-
-For example, to force a loop onto the host execution space:
+launch on and is defined above as the same enum. For example, to force
+a loop onto the host execution space:
 
 .. code-block:: cpp
 

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -37,40 +37,42 @@ portability.hpp
 ``portability.hpp`` provides the above-mentioned macros for decorating
 functions. It also provides several additional abstractions:
 
-.. cpp:function:: PortsOfCall::portableMalloc(Exec e, std::size_t size_bytes)
+.. cpp:function:: template <typename E>PortsOfCall::portableMalloc(E e, std::size_t size_bytes)
 
 and
 
-.. cpp:function:: template<typename T> PortsOfCall::portableFree(Exec e, T *ptr)
+.. cpp:function:: template<typename E, typename T> PortsOfCall::portableFree(E e, T *ptr)
 
-allocate and free memory respectively, where the enum ``Exec`` may be
-either ``PortsOfCall::Exec::Host`` or
-``PortsOfCall::Exec::Device``. The ``Exec`` argument is
-optional. These are also the backend for macros ``PORTABLE_MALLOC``
+allocate and free memory respectively, where the type ``E`` determines
+the space where data is allocated and may be
+``PortsOfCall::Exec::Host``, ``PortsOfCall::Exec::Device``, or any
+type allowed by your backend. The selection of memory/execution space
+is optional, and defaults to ``PortsOfCall::Exec::Device``.
+
+These are also the backend for macros ``PORTABLE_MALLOC``
 and ``PORTABLE_FREE``.
 
 ``portability.hpp`` also provides loop abstractions that can be
 leveraged by a code. These loop abstractions are of the form:
 
-.. cpp:function:: template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function> void portableFor(const char *name, int start, int stop, Function function)
+.. cpp:function:: template <typename E, typename Function> void portableFor(const char *name, E e, int start, int stop, Function function)
 
 where ``Function`` is a template parameter and should be set to a
 functor that takes one index, e.g., an index in an array. For example:
 
 .. code-block:: cpp
 
-  portableFor("Example", 0, 5,
+  portableFor("Example host", PortsOfCall::Exec::Host, 0, 5,
     PORTABLE_LAMBDA(int i) {
       printf("hello from thread %d\n", i);
   });
 
 The optional template parameter ``E`` selects the execution space to
-launch on and is defined above as the same enum. For example, to force
-a loop onto the host execution space:
+launch on and is defined above. It is optional, and defaults to device:
 
 .. code-block:: cpp
 
-  portableFor<PortsOfCall::Exec::Host>("ExampleHost", 0, 5,
+  portableFor("Example device", 0, 5,
     PORTABLE_LAMBDA(int i) {
       printf("hello from host thread %d\n", i);
   });
@@ -80,8 +82,8 @@ a loop onto the host execution space:
 
 .. code-block:: cpp
 
-  template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
-  void portableFor(const char *name, int startb, int stopb, int starta, int stopa,
+  template <typename E, typename Function>
+  void portableFor(const char *name, E e, int startb, int stopb, int starta, int stopa,
     int startz, int stopz, int starty, int stopy, int startx,
     int stopx, Function function) {
 
@@ -90,8 +92,8 @@ limited. The syntax is:
 
 .. code-block::
 
-  template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
-  void portableReduce(const char *name, int starta, int stopa, int startz,
+  template <typename E, typename Function, typename T>
+  void portableReduce(const char *name, E e, int starta, int stopa, int startz,
     int stopz, int starty, int stopy, int startx, int stopx,
     Function function, T &reduced) {
 
@@ -100,14 +102,14 @@ where ``Function`` now takes as many indices are required and
 device synchronization step is performed) while `portableFor()` may not be,
 possibly requiring a ``PORTABLE_FENCE`` to avoid any race conditions.
 
-As with ``portableFor``, the optional ``E`` template parameter can be
+As with ``portableFor``, the optional ``E`` argument can be
 used to select host or device execution explicitly. For example:
 
 .. code-block:: cpp
 
   int sum = 0;
-  portableReduce<PortsOfCall::Exec::Host>(
-    "HostReduce", 0, 5,
+  portableReduce(
+    "HostReduce", PortsOfCall::Exec::Host(), 0, 5,
     PORTABLE_LAMBDA(int i, int &local_sum) {
       local_sum += i;
     }, sum);

--- a/plan_histories/MR109.md
+++ b/plan_histories/MR109.md
@@ -1,0 +1,194 @@
+# Proposed `portableFor` / `portableReduce` Execution-Space API
+
+## Goal
+
+Allow `portableFor` and `portableReduce` to launch on either the device execution
+space or the host execution space under Kokkos, while preserving current behavior
+and keeping call-site boilerplate minimal.
+
+## Current Behavior
+
+Today the Kokkos implementations in `ports-of-call/portability.hpp` use
+`Kokkos::RangePolicy<>` and `Kokkos::MDRangePolicy<Kokkos::Rank<N>>`, which bind
+implicitly to `Kokkos::DefaultExecutionSpace`.
+
+That means:
+
+- Existing `portableFor(...)` launches on the default execution space.
+- Existing `portableReduce(...)` launches on the default execution space.
+- In practice, for many Kokkos builds, that means device launch.
+
+## Proposed Public API
+
+Introduce a small execution-space selector in the `PortsOfCall` namespace and add
+it as an optional template parameter with a default that preserves current
+behavior.
+
+```cpp
+namespace PortsOfCall {
+
+enum class Exec { Device, Host };
+
+template <Exec E>
+struct ExecSpace;
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+template <>
+struct ExecSpace<Exec::Device> {
+  using type = Kokkos::DefaultExecutionSpace;
+};
+
+template <>
+struct ExecSpace<Exec::Host> {
+  using type = Kokkos::DefaultHostExecutionSpace;
+};
+#else
+template <>
+struct ExecSpace<Exec::Device> {
+  struct type {};
+};
+
+template <>
+struct ExecSpace<Exec::Host> {
+  struct type {};
+};
+#endif
+
+} // namespace PortsOfCall
+```
+
+Then update each overload to follow this pattern:
+
+```cpp
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
+void portableFor(const char *name, int start, int stop, Function function);
+
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
+void portableReduce(const char *name, int start, int stop, Function function, T &reduced);
+```
+
+The same defaulted template parameter would be added to the 2D through 5D
+overloads.
+
+## Example Call Sites
+
+Existing call sites remain unchanged:
+
+```cpp
+portableFor("foo", 0, n, PORTABLE_LAMBDA(const int i) {
+  // existing behavior preserved
+});
+
+portableReduce("sum", 0, n, PORTABLE_LAMBDA(const int i, double &local) {
+  local += x(i);
+}, result);
+```
+
+Host execution can be requested explicitly:
+
+```cpp
+portableFor<PortsOfCall::Exec::Host>("foo", 0, n, PORTABLE_LAMBDA(const int i) {
+  // run on host execution space
+});
+
+portableReduce<PortsOfCall::Exec::Host>(
+    "sum", 0, n,
+    PORTABLE_LAMBDA(const int i, double &local) { local += x(i); }, result);
+```
+
+## Implementation Strategy
+
+### 1. Add the selector and execution-space mapper
+
+Define `PortsOfCall::Exec` plus `PortsOfCall::ExecSpace<E>::type` near the other
+Kokkos-specific compile-time utilities in `portability.hpp`.
+
+### 2. Default all launches to `Exec::Device`
+
+This keeps all existing call sites source-compatible and preserves current
+semantics.
+
+### 3. Swap implicit Kokkos policies for execution-space-aware policies
+
+For 1D loops:
+
+```cpp
+using Policy = Kokkos::RangePolicy<typename PortsOfCall::ExecSpace<E>::type>;
+Kokkos::parallel_for(name, Policy(start, stop), function);
+```
+
+For `MDRangePolicy`:
+
+```cpp
+using Policy2D =
+    Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<2>>;
+```
+
+and likewise for ranks 3 through 5.
+
+For reductions:
+
+```cpp
+using Policy = Kokkos::RangePolicy<typename PortsOfCall::ExecSpace<E>::type>;
+Kokkos::parallel_reduce(name, Policy(start, stop), function, reduced);
+```
+
+### 4. Keep non-Kokkos builds simple
+
+Outside the Kokkos path, the new template parameter can be ignored. Both
+`Exec::Device` and `Exec::Host` would continue to run the existing serial host
+loops.
+
+This avoids introducing unnecessary abstraction into the non-Kokkos backend.
+
+## Why This API
+
+- Backward compatible: current call sites still compile and keep the same
+  behavior.
+- Minimal boilerplate: only call sites that need host execution opt in with an
+  explicit template argument.
+- Narrow surface area: the public API exposes only the intended choice, host vs
+  device, rather than raw Kokkos execution-space types.
+- Mechanical implementation: the required source changes are mostly small,
+  repeated substitutions in the current overloads.
+
+## Alternative: Expose Raw Kokkos Execution Spaces
+
+An alternative would be:
+
+```cpp
+template <typename ExecSpace = Kokkos::DefaultExecutionSpace, typename Function>
+void portableFor(...);
+```
+
+This is more flexible, but it leaks Kokkos types directly into the public API and
+is broader than the current requirement. If the intended user-facing choice is
+just host vs device, the enum-based selector is the cleaner interface.
+
+## Caveats
+
+- The lambda or functor must be valid for the selected execution space. A
+  host-only launch cannot compile code that depends on device-only operations.
+- Changing execution space does not change memory-space accessibility. Host
+  execution still requires data that is accessible from the host.
+- The meaning of `Exec::Device` here is "the current default Kokkos execution
+  space", which matches existing behavior. If a stricter notion of "device" is
+  needed later, that should be a separate design discussion.
+
+## Suggested Patch Shape
+
+At a high level, the code changes in `ports-of-call/portability.hpp` would be:
+
+1. Add `PortsOfCall::Exec`.
+2. Add `PortsOfCall::ExecSpace<E>::type`.
+3. Add `template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, ...>` to each
+   `portableFor` overload.
+4. Add `template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, ...>` to each
+   `portableReduce` overload.
+5. Replace `RangePolicy<>` and `MDRangePolicy<Kokkos::Rank<N>>` with
+   execution-space-aware forms.
+
+## Files Impacted
+
+- `ports-of-call/portability.hpp`
+

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -344,6 +344,15 @@ void portableFor([[maybe_unused]] const char *name, int startb, int stopb, int s
 #endif
 }
 
+template <typename... Args>
+void portableFor([[maybe_unused]] const char *name, PortsOfCall::Exec e, Args &&...args) {
+  if (e == PortsOfCall::Exec::Device) {
+    portableFor<PortsOfCall::Exec::Device>(name, std::forward<Args>(args)...);
+  } else { // host
+    portableFor<PortsOfCall::Exec::Host>(name, std::forward<Args>(args)...);
+  }
+}
+
 template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int start, int stop,
                     Function function, T &reduced) {
@@ -440,6 +449,16 @@ void portableReduce([[maybe_unused]] const char *name, int startb, int stopb, in
     }
   }
 #endif
+}
+
+template <typename... Args>
+void portableReduce([[maybe_unused]] const char *name, PortsOfCall::Exec e,
+                    Args &&...args) {
+  if (e == PortsOfCall::Exec::Device) {
+    portableReduce<PortsOfCall::Exec::Device>(name, std::forward<Args>(args)...);
+  } else { // host
+    portableReduce<PortsOfCall::Exec::Host>(name, std::forward<Args>(args)...);
+  }
 }
 
 #endif // PORTABILITY_HPP

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -258,8 +258,8 @@ void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
                  const Function &function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy3D = Kokkos::MDRangePolicy<E, Kokkos::Rank<3>>;
-  Kokkos::parallel_for(
-      name, Policy3D(space, {startz, starty, startx}, {stopz, stopy, stopx}), function);
+  Kokkos::parallel_for(name, Policy3D(e, {startz, starty, startx}, {stopz, stopy, stopx}),
+                       function);
 #else
   for (int iz = startz; iz < stopz; iz++) {
     for (int iy = starty; iy < stopy; iy++) {
@@ -279,8 +279,7 @@ void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy4D = Kokkos::MDRangePolicy<E, Kokkos::Rank<4>>;
   Kokkos::parallel_for(
-      name,
-      Policy4D(space, {starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
+      name, Policy4D(e, {starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
       function);
 #else
   for (int ia = starta; ia < stopa; ia++) {
@@ -303,7 +302,7 @@ void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy5D = Kokkos::MDRangePolicy<E, Kokkos::Rank<5>>;
   Kokkos::parallel_for(name,
-                       Policy5D(space, {startb, starta, startz, starty, startx},
+                       Policy5D(e, {startb, starta, startz, starty, startx},
                                 {stopb, stopa, stopz, stopy, stopx}),
                        function);
 #else
@@ -323,16 +322,17 @@ void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
 
 template <typename Head, typename... Tail,
           typename = std::enable_if_t<std::is_arithmetic_v<Head>>>
-void portableFor([[maybe_unused]] const char *name, Head &&h, Tail&&...tail) {
+void portableFor([[maybe_unused]] const char *name, Head &&h, Tail &&...tail) {
   portableFor(name, PortsOfCall::Exec::Device(), h, std::forward<Tail>(tail)...);
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
-void portableReduce([[maybe_unused]] const char *name, int start, int stop,
-                    Function function, T &reduced) {
+template <typename E, typename Function, typename T,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableReduce([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                    int start, int stop, const Function &function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy = Kokkos::RangePolicy<E>;
-  Kokkos::parallel_reduce(name, Policy(start, stop), function, reduced);
+  Kokkos::parallel_reduce(name, Policy(e, start, stop), function, reduced);
 #else
   for (int i = start; i < stop; i++) {
     function(i, reduced);
@@ -340,12 +340,14 @@ void portableReduce([[maybe_unused]] const char *name, int start, int stop,
 #endif
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
-void portableReduce([[maybe_unused]] const char *name, int starty, int stopy, int startx,
-                    int stopx, Function function, T &reduced) {
+template <typename E, typename Function, typename T,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableReduce([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                    int starty, int stopy, int startx, int stopx,
+                    const Function &function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy2D = Kokkos::MDRangePolicy<E, Kokkos::Rank<2>>;
-  Kokkos::parallel_reduce(name, Policy2D({starty, startx}, {stopy, stopx}), function,
+  Kokkos::parallel_reduce(name, Policy2D(e, {starty, startx}, {stopy, stopx}), function,
                           reduced);
 #else
   for (int iy = starty; iy < stopy; iy++) {
@@ -356,12 +358,15 @@ void portableReduce([[maybe_unused]] const char *name, int starty, int stopy, in
 #endif
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
-void portableReduce([[maybe_unused]] const char *name, int startz, int stopz, int starty,
-                    int stopy, int startx, int stopx, Function function, T &reduced) {
+template <typename E, typename Function, typename T,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableReduce([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                    int startz, int stopz, int starty, int stopy, int startx, int stopx,
+                    const Function &function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy3D = Kokkos::MDRangePolicy<E, Kokkos::Rank<3>>;
-  Kokkos::parallel_reduce(name, Policy3D({startz, starty, startx}, {stopz, stopy, stopx}),
+  Kokkos::parallel_reduce(name,
+                          Policy3D(e, {startz, starty, startx}, {stopz, stopy, stopx}),
                           function, reduced);
 #else
   for (int iz = startz; iz < stopz; iz++) {
@@ -374,14 +379,15 @@ void portableReduce([[maybe_unused]] const char *name, int startz, int stopz, in
 #endif
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
-void portableReduce([[maybe_unused]] const char *name, int starta, int stopa, int startz,
-                    int stopz, int starty, int stopy, int startx, int stopx,
-                    Function function, T &reduced) {
+template <typename E, typename Function, typename T,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableReduce([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                    int starta, int stopa, int startz, int stopz, int starty, int stopy,
+                    int startx, int stopx, const Function &function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy4D = Kokkos::MDRangePolicy<E, Kokkos::Rank<4>>;
   Kokkos::parallel_reduce(
-      name, Policy4D({starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
+      name, Policy4D(e, {starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
       function, reduced);
 #else
   for (int ia = starta; ia < stopa; ia++) {
@@ -396,14 +402,16 @@ void portableReduce([[maybe_unused]] const char *name, int starta, int stopa, in
 #endif
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
-void portableReduce([[maybe_unused]] const char *name, int startb, int stopb, int starta,
-                    int stopa, int startz, int stopz, int starty, int stopy, int startx,
-                    int stopx, Function function, T &reduced) {
+template <typename E, typename Function, typename T,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableReduce([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                    int startb, int stopb, int starta, int stopa, int startz, int stopz,
+                    int starty, int stopy, int startx, int stopx,
+                    const Function &function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy5D = Kokkos::MDRangePolicy<E, Kokkos::Rank<5>>;
   Kokkos::parallel_reduce(name,
-                          Policy5D({startb, starta, startz, starty, startx},
+                          Policy5D(e, {startb, starta, startz, starty, startx},
                                    {stopb, stopa, stopz, stopy, stopx}),
                           function, reduced);
 #else
@@ -421,11 +429,10 @@ void portableReduce([[maybe_unused]] const char *name, int startb, int stopb, in
 #endif
 }
 
-template <typename E, typename = std::enable_if_t<!std::is_arithmetic_v<E>>,
-          typename... Args>
-void portableReduce([[maybe_unused]] const char *name, [[maybe_unused]] E e,
-                    Args &&...args) {
-  portableReduce<E>(name, std::forward<Args>(args)...);
+template <typename Head, typename... Tail,
+          typename = std::enable_if_t<std::is_arithmetic_v<Head>>>
+void portableReduce([[maybe_unused]] const char *name, Head &&h, Tail &&...tail) {
+  portableReduce(name, PortsOfCall::Exec::Device(), h, std::forward<Tail>(tail)...);
 }
 
 #endif // PORTABILITY_HPP

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -18,6 +18,8 @@
 
 // This file was generated in part with generative AI
 
+#include <cstdlib>
+
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -53,9 +55,6 @@
 #define PORTABLE_FORCEINLINE_FUNCTION KOKKOS_FORCEINLINE_FUNCTION
 #define PORTABLE_LAMBDA KOKKOS_LAMBDA
 #define _WITH_KOKKOS_
-// The following is a malloc on default memory space
-#define PORTABLE_MALLOC(size) Kokkos::kokkos_malloc<>(size)
-#define PORTABLE_FREE(ptr) Kokkos::kokkos_free<>(ptr)
 // Do we want to include additional terms here (for memory spaces, etc.)?
 #define PORTABLE_FENCE(...) Kokkos::fence(__VA_ARGS__)
 #else
@@ -67,12 +66,6 @@
 #define PORTABLE_INLINE_FUNCTION __host__ __device__ inline
 #define PORTABLE_FORCEINLINE_FUNCTION __host__ __device__ POC_ALWAYS_INLINE
 #define PORTABLE_LAMBDA [=] __host__ __device__
-void *PORTABLE_MALLOC(size_t size) {
-  void *devPtr = nullptr;
-  cudaError_t e = cudaMalloc(&devPtr, size);
-  return devPtr;
-}
-void PORTABLE_FREE(void *ptr) { cudaError_t e = cudaFree(ptr); }
 #define PORTABLE_FENCE(...) cudaDeviceSynchronize()
 #define _WITH_CUDA_
 // It is worth noting here that we will not define
@@ -83,11 +76,11 @@ void PORTABLE_FREE(void *ptr) { cudaError_t e = cudaFree(ptr); }
 #define PORTABLE_INLINE_FUNCTION inline
 #define PORTABLE_FORCEINLINE_FUNCTION POC_ALWAYS_INLINE
 #define PORTABLE_LAMBDA [=]
-#define PORTABLE_MALLOC(size) malloc(size)
-#define PORTABLE_FREE(ptr) free(ptr)
 #define PORTABLE_FENCE(...)
 #endif
 #endif
+#define PORTABLE_MALLOC(...) PortsOfCall::portableMalloc(__VA_ARGS__)
+#define PORTABLE_FREE(...) PortsOfCall::portableFree(__VA_ARGS__)
 
 #ifndef SINGLE_PRECISION_ENABLED
 #define SINGLE_PRECISION_ENABLED 0
@@ -151,6 +144,60 @@ PORTABLE_INLINE_FUNCTION void snprintf(char *target, std::size_t size,
 #endif // __HIPCC__
   return;
 }
+
+template <Exec E>
+inline auto portableMalloc(std::size_t size_bytes) {
+  void *ret;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  ret = Kokkos::kokkos_malloc<typename ExecSpace<E>::type::memory_space>(size_bytes);
+#elif defined(PORTABILITY_STRATEGY_CUDA)
+  if constexpr (space == Exec::Device) {
+    cudaError_t e = cudaMalloc(&ret, size_bytes);
+  } else {
+    ret = malloc(size_bytes);
+  }
+#else  // PORTABILITY_STRATEGY_NONE
+  ret = std::malloc(size_bytes);
+#endif // PORTABILITY STRATEGY
+  return ret;
+}
+inline auto portableMalloc(std::size_t size_bytes) {
+  return portableMalloc<Exec::Device>(size_bytes);
+}
+inline auto portableMalloc(Exec e, std::size_t size_bytes) {
+  if (e == Exec::Device) {
+    return portableMalloc<Exec::Device>(size_bytes);
+  } else { // if (e == Exec::Host) {
+    return portableMalloc<Exec::Host>(size_bytes);
+  }
+}
+
+template <Exec E, typename T>
+void portableFree(T *p) {
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::kokkos_free<typename ExecSpace<E>::type::memory_space>(p);
+#elif defined(PORTABILITY_STRATEGY_CUDA)
+  if constexpr (space == Exec::Device) {
+    cudaError_t e = cudaFree(p);
+  } else {
+    std::free(p);
+  }
+#else  // PORTABILITY_STRATEGY_NONE
+  std::free(p);
+#endif // PORTABILITY STRATEGY
+}
+template <typename T>
+void portableFree(T *p) {
+  portableFree<Exec::Device>(p);
+}
+template <typename T>
+void portableFree(Exec e, T *p) {
+  if (e == Exec::Device) {
+    portableFree<Exec::Device>(p);
+  } else { // Exec::Host
+    portableFree<Exec::Host>(p);
+  }
+}
 } // namespace PortsOfCall
 
 template <typename T>
@@ -161,7 +208,7 @@ void portableCopyToDevice(T *const to, T const *const from, size_t const size_by
   using HS = Kokkos::HostSpace;
   Kokkos::View<const T *, HS, UM> from_v(from, length);
   Kokkos::View<T *, UM> to_v(to, length);
-  deep_copy(to_v, from_v);
+  Kokkos::deep_copy(to_v, from_v);
 #elif defined(PORTABILITY_STRATEGY_CUDA)
   cudaMemcpy(to, from, size_bytes, cudaMemcpyHostToDevice);
 #else
@@ -180,7 +227,7 @@ void portableCopyToHost(T *const to, T const *const from, size_t const size_byte
   using HS = Kokkos::HostSpace;
   Kokkos::View<const T *, UM> from_v(from, length);
   Kokkos::View<T *, HS, UM> to_v(to, length);
-  deep_copy(to_v, from_v);
+  Kokkos::deep_copy(to_v, from_v);
 #elif defined(PORTABILITY_STRATEGY_CUDA)
   cudaMemcpy(to, from, size_bytes, cudaMemcpyDeviceToHost);
 #else
@@ -190,9 +237,19 @@ void portableCopyToHost(T *const to, T const *const from, size_t const size_byte
 #endif
   return;
 }
+template <typename T>
+void portableCopy(PortsOfCall::Exec e, T *const to, T const *const from,
+                  size_t const size_bytes) {
+  if (e == PortsOfCall::Exec::Device) {
+    portableCopyToDevice(to, from, size_bytes);
+  } else { // host
+    portableCopyToHost(to, from, size_bytes);
+  }
+}
 
 template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
-void portableFor([[maybe_unused]] const char *name, int start, int stop, Function function) {
+void portableFor([[maybe_unused]] const char *name, int start, int stop,
+                 Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using policy = Kokkos::RangePolicy<typename PortsOfCall::ExecSpace<E>::type>;
   Kokkos::parallel_for(name, policy(start, stop), function);

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -109,6 +109,24 @@ constexpr bool EXECUTION_IS_HOST{false};
 #else
 constexpr bool EXECUTION_IS_HOST{true};
 #endif
+
+enum class Exec { Device, Host };
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+template <Exec E>
+struct ExecSpace;
+
+template <>
+struct ExecSpace<Exec::Device> {
+  using type = Kokkos::DefaultExecutionSpace;
+};
+
+template <>
+struct ExecSpace<Exec::Host> {
+  using type = Kokkos::DefaultHostExecutionSpace;
+};
+#endif
+
 // portable printf
 #define PORTABLE_MAX_NUM_CHAR (2048)
 template <typename... Ts>
@@ -171,11 +189,10 @@ void portableCopyToHost(T *const to, T const *const from, size_t const size_byte
   return;
 }
 
-template <typename Function>
-void portableFor([[maybe_unused]] const char *name, int start, int stop,
-                 Function function) {
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
+void portableFor([[maybe_unused]] const char *name, int start, int stop, Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using policy = Kokkos::RangePolicy<>;
+  using policy = Kokkos::RangePolicy<typename PortsOfCall::ExecSpace<E>::type>;
   Kokkos::parallel_for(name, policy(start, stop), function);
 #else
   for (int i = start; i < stop; i++) {
@@ -184,11 +201,12 @@ void portableFor([[maybe_unused]] const char *name, int start, int stop,
 #endif
 }
 
-template <typename Function>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int starty, int stopy, int startx,
                  int stopx, Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy2D = Kokkos::MDRangePolicy<Kokkos::Rank<2>>;
+  using Policy2D =
+      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<2>>;
   Kokkos::parallel_for(name, Policy2D({starty, startx}, {stopy, stopx}), function);
 #else
   for (int iy = starty; iy < stopy; iy++) {
@@ -199,11 +217,12 @@ void portableFor([[maybe_unused]] const char *name, int starty, int stopy, int s
 #endif
 }
 
-template <typename Function>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int startz, int stopz, int starty,
                  int stopy, int startx, int stopx, Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy3D = Kokkos::MDRangePolicy<Kokkos::Rank<3>>;
+  using Policy3D =
+      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<3>>;
   Kokkos::parallel_for(name, Policy3D({startz, starty, startx}, {stopz, stopy, stopx}),
                        function);
 #else
@@ -217,12 +236,13 @@ void portableFor([[maybe_unused]] const char *name, int startz, int stopz, int s
 #endif
 }
 
-template <typename Function>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int starta, int stopa, int startz,
                  int stopz, int starty, int stopy, int startx, int stopx,
                  Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
+  using Policy4D =
+      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<4>>;
   Kokkos::parallel_for(
       name, Policy4D({starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
       function);
@@ -239,12 +259,13 @@ void portableFor([[maybe_unused]] const char *name, int starta, int stopa, int s
 #endif
 }
 
-template <typename Function>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int startb, int stopb, int starta,
                  int stopa, int startz, int stopz, int starty, int stopy, int startx,
                  int stopx, Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy5D = Kokkos::MDRangePolicy<Kokkos::Rank<5>>;
+  using Policy5D =
+      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<5>>;
   Kokkos::parallel_for(name,
                        Policy5D({startb, starta, startz, starty, startx},
                                 {stopb, stopa, stopz, stopy, stopx}),
@@ -264,11 +285,11 @@ void portableFor([[maybe_unused]] const char *name, int startb, int stopb, int s
 #endif
 }
 
-template <typename Function, typename T>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int start, int stop,
                     Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy = Kokkos::RangePolicy<>;
+  using Policy = Kokkos::RangePolicy<typename PortsOfCall::ExecSpace<E>::type>;
   Kokkos::parallel_reduce(name, Policy(start, stop), function, reduced);
 #else
   for (int i = start; i < stop; i++) {
@@ -277,11 +298,12 @@ void portableReduce([[maybe_unused]] const char *name, int start, int stop,
 #endif
 }
 
-template <typename Function, typename T>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int starty, int stopy, int startx,
                     int stopx, Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy2D = Kokkos::MDRangePolicy<Kokkos::Rank<2>>;
+  using Policy2D =
+      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<2>>;
   Kokkos::parallel_reduce(name, Policy2D({starty, startx}, {stopy, stopx}), function,
                           reduced);
 #else
@@ -293,11 +315,12 @@ void portableReduce([[maybe_unused]] const char *name, int starty, int stopy, in
 #endif
 }
 
-template <typename Function, typename T>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int startz, int stopz, int starty,
                     int stopy, int startx, int stopx, Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy3D = Kokkos::MDRangePolicy<Kokkos::Rank<3>>;
+  using Policy3D =
+      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<3>>;
   Kokkos::parallel_reduce(name, Policy3D({startz, starty, startx}, {stopz, stopy, stopx}),
                           function, reduced);
 #else
@@ -311,12 +334,13 @@ void portableReduce([[maybe_unused]] const char *name, int startz, int stopz, in
 #endif
 }
 
-template <typename Function, typename T>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int starta, int stopa, int startz,
                     int stopz, int starty, int stopy, int startx, int stopx,
                     Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
+  using Policy4D =
+      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<4>>;
   Kokkos::parallel_reduce(
       name, Policy4D({starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
       function, reduced);
@@ -333,12 +357,13 @@ void portableReduce([[maybe_unused]] const char *name, int starta, int stopa, in
 #endif
 }
 
-template <typename Function, typename T>
+template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int startb, int stopb, int starta,
                     int stopa, int startz, int stopz, int starty, int stopy, int startx,
                     int stopx, Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy5D = Kokkos::MDRangePolicy<Kokkos::Rank<5>>;
+  using Policy5D =
+      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<5>>;
   Kokkos::parallel_reduce(name,
                           Policy5D({startb, starta, startz, starty, startx},
                                    {stopb, stopa, stopz, stopy, stopx}),

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -16,6 +16,8 @@
 // permit others to do so.
 // ========================================================================================
 
+// This file was generated in part with generative AI
+
 #include <string>
 #include <string_view>
 #include <type_traits>

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -79,7 +79,7 @@
 #define PORTABLE_FENCE(...)
 #endif
 #endif
-#define PORTABLE_MALLOC(...) PortsOfCall::portableMalloc(__VA_ARGS__)
+#define PORTABLE_MALLOC(...) PortsOfCall::portableMalloc<>(__VA_ARGS__)
 #define PORTABLE_FREE(...) PortsOfCall::portableFree(__VA_ARGS__)
 
 #ifndef SINGLE_PRECISION_ENABLED
@@ -105,22 +105,15 @@ constexpr bool EXECUTION_IS_HOST{false};
 constexpr bool EXECUTION_IS_HOST{true};
 #endif
 
-enum class Exec { Device, Host };
-
+namespace Exec {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-template <Exec E>
-struct ExecSpace;
-
-template <>
-struct ExecSpace<Exec::Device> {
-  using type = Kokkos::DefaultExecutionSpace;
-};
-
-template <>
-struct ExecSpace<Exec::Host> {
-  using type = Kokkos::DefaultHostExecutionSpace;
-};
-#endif
+using Device = Kokkos::DefaultExecutionSpace;
+using Host = Kokkos::DefaultHostExecutionSpace;
+#else  // otherwise
+struct Device {};
+struct Host {};
+#endif // PORTABILITY_STRATEGY_KOKKOS
+} // namespace Exec
 
 // portable printf
 #define PORTABLE_MAX_NUM_CHAR (2048)
@@ -145,39 +138,35 @@ PORTABLE_INLINE_FUNCTION void snprintf(char *target, std::size_t size,
   return;
 }
 
-template <Exec E>
-inline auto portableMalloc(std::size_t size_bytes) {
+template <typename E>
+inline auto portableMalloc([[maybe_unused]] E e, std::size_t size_bytes) {
   void *ret;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  ret = Kokkos::kokkos_malloc<typename ExecSpace<E>::type::memory_space>(size_bytes);
+  ret = Kokkos::kokkos_malloc<typename E::memory_space>(size_bytes);
 #elif defined(PORTABILITY_STRATEGY_CUDA)
-  if constexpr (space == Exec::Device) {
+  if constexpr (std::is_same_v < E, Exec::Device) {
     cudaError_t e = cudaMalloc(&ret, size_bytes);
-  } else {
+  } else if constexpr (std::is_same_v < E, Exec::Host) {
     ret = malloc(size_bytes);
+  } else {
+    throw
   }
 #else  // PORTABILITY_STRATEGY_NONE
   ret = std::malloc(size_bytes);
 #endif // PORTABILITY STRATEGY
   return ret;
 }
+template <typename E = Exec::Device>
 inline auto portableMalloc(std::size_t size_bytes) {
-  return portableMalloc<Exec::Device>(size_bytes);
-}
-inline auto portableMalloc(Exec e, std::size_t size_bytes) {
-  if (e == Exec::Device) {
-    return portableMalloc<Exec::Device>(size_bytes);
-  } else { // if (e == Exec::Host) {
-    return portableMalloc<Exec::Host>(size_bytes);
-  }
+  return portableMalloc(E(), size_bytes);
 }
 
-template <Exec E, typename T>
-void portableFree(T *p) {
+template <typename E, typename T>
+void portableFree([[maybe_unused]] E e, T *p) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  Kokkos::kokkos_free<typename ExecSpace<E>::type::memory_space>(p);
+  Kokkos::kokkos_free<typename E::memory_space>(p);
 #elif defined(PORTABILITY_STRATEGY_CUDA)
-  if constexpr (space == Exec::Device) {
+  if constexpr (std::is_same_v<E, Device>) {
     cudaError_t e = cudaFree(p);
   } else {
     std::free(p);
@@ -188,18 +177,12 @@ void portableFree(T *p) {
 }
 template <typename T>
 void portableFree(T *p) {
-  portableFree<Exec::Device>(p);
+  portableFree(Exec::Device(), p);
 }
-template <typename T>
-void portableFree(Exec e, T *p) {
-  if (e == Exec::Device) {
-    portableFree<Exec::Device>(p);
-  } else { // Exec::Host
-    portableFree<Exec::Host>(p);
-  }
-}
+
 } // namespace PortsOfCall
 
+// TODO(JMM): Pass in exec space here later
 template <typename T>
 void portableCopyToDevice(T *const to, T const *const from, size_t const size_bytes) {
   auto const length = size_bytes / sizeof(T);
@@ -237,21 +220,12 @@ void portableCopyToHost(T *const to, T const *const from, size_t const size_byte
 #endif
   return;
 }
-template <typename T>
-void portableCopy(PortsOfCall::Exec e, T *const to, T const *const from,
-                  size_t const size_bytes) {
-  if (e == PortsOfCall::Exec::Device) {
-    portableCopyToDevice(to, from, size_bytes);
-  } else { // host
-    portableCopyToHost(to, from, size_bytes);
-  }
-}
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
+template <typename E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int start, int stop,
                  Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using policy = Kokkos::RangePolicy<typename PortsOfCall::ExecSpace<E>::type>;
+  using policy = Kokkos::RangePolicy<E>;
   Kokkos::parallel_for(name, policy(start, stop), function);
 #else
   for (int i = start; i < stop; i++) {
@@ -260,12 +234,11 @@ void portableFor([[maybe_unused]] const char *name, int start, int stop,
 #endif
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
+template <typename E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int starty, int stopy, int startx,
                  int stopx, Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy2D =
-      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<2>>;
+  using Policy2D = Kokkos::MDRangePolicy<E, Kokkos::Rank<2>>;
   Kokkos::parallel_for(name, Policy2D({starty, startx}, {stopy, stopx}), function);
 #else
   for (int iy = starty; iy < stopy; iy++) {
@@ -276,12 +249,11 @@ void portableFor([[maybe_unused]] const char *name, int starty, int stopy, int s
 #endif
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
+template <typename E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int startz, int stopz, int starty,
                  int stopy, int startx, int stopx, Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy3D =
-      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<3>>;
+  using Policy3D = Kokkos::MDRangePolicy<E, Kokkos::Rank<3>>;
   Kokkos::parallel_for(name, Policy3D({startz, starty, startx}, {stopz, stopy, stopx}),
                        function);
 #else
@@ -295,13 +267,12 @@ void portableFor([[maybe_unused]] const char *name, int startz, int stopz, int s
 #endif
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
+template <typename E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int starta, int stopa, int startz,
                  int stopz, int starty, int stopy, int startx, int stopx,
                  Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy4D =
-      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<4>>;
+  using Policy4D = Kokkos::MDRangePolicy<E, Kokkos::Rank<4>>;
   Kokkos::parallel_for(
       name, Policy4D({starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
       function);
@@ -318,13 +289,12 @@ void portableFor([[maybe_unused]] const char *name, int starta, int stopa, int s
 #endif
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function>
+template <typename E = PortsOfCall::Exec::Device, typename Function>
 void portableFor([[maybe_unused]] const char *name, int startb, int stopb, int starta,
                  int stopa, int startz, int stopz, int starty, int stopy, int startx,
                  int stopx, Function function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy5D =
-      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<5>>;
+  using Policy5D = Kokkos::MDRangePolicy<E, Kokkos::Rank<5>>;
   Kokkos::parallel_for(name,
                        Policy5D({startb, starta, startz, starty, startx},
                                 {stopb, stopa, stopz, stopy, stopx}),
@@ -344,20 +314,18 @@ void portableFor([[maybe_unused]] const char *name, int startb, int stopb, int s
 #endif
 }
 
-template <typename... Args>
-void portableFor([[maybe_unused]] const char *name, PortsOfCall::Exec e, Args &&...args) {
-  if (e == PortsOfCall::Exec::Device) {
-    portableFor<PortsOfCall::Exec::Device>(name, std::forward<Args>(args)...);
-  } else { // host
-    portableFor<PortsOfCall::Exec::Host>(name, std::forward<Args>(args)...);
-  }
+template <typename E, typename = std::enable_if_t<!std::is_arithmetic_v<E>>,
+          typename... Args>
+void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] E e,
+                 Args &&...args) {
+  portableFor<E>(name, std::forward<Args>(args)...);
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
+template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int start, int stop,
                     Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy = Kokkos::RangePolicy<typename PortsOfCall::ExecSpace<E>::type>;
+  using Policy = Kokkos::RangePolicy<E>;
   Kokkos::parallel_reduce(name, Policy(start, stop), function, reduced);
 #else
   for (int i = start; i < stop; i++) {
@@ -366,12 +334,11 @@ void portableReduce([[maybe_unused]] const char *name, int start, int stop,
 #endif
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
+template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int starty, int stopy, int startx,
                     int stopx, Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy2D =
-      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<2>>;
+  using Policy2D = Kokkos::MDRangePolicy<E, Kokkos::Rank<2>>;
   Kokkos::parallel_reduce(name, Policy2D({starty, startx}, {stopy, stopx}), function,
                           reduced);
 #else
@@ -383,12 +350,11 @@ void portableReduce([[maybe_unused]] const char *name, int starty, int stopy, in
 #endif
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
+template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int startz, int stopz, int starty,
                     int stopy, int startx, int stopx, Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy3D =
-      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<3>>;
+  using Policy3D = Kokkos::MDRangePolicy<E, Kokkos::Rank<3>>;
   Kokkos::parallel_reduce(name, Policy3D({startz, starty, startx}, {stopz, stopy, stopx}),
                           function, reduced);
 #else
@@ -402,13 +368,12 @@ void portableReduce([[maybe_unused]] const char *name, int startz, int stopz, in
 #endif
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
+template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int starta, int stopa, int startz,
                     int stopz, int starty, int stopy, int startx, int stopx,
                     Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy4D =
-      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<4>>;
+  using Policy4D = Kokkos::MDRangePolicy<E, Kokkos::Rank<4>>;
   Kokkos::parallel_reduce(
       name, Policy4D({starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
       function, reduced);
@@ -425,13 +390,12 @@ void portableReduce([[maybe_unused]] const char *name, int starta, int stopa, in
 #endif
 }
 
-template <PortsOfCall::Exec E = PortsOfCall::Exec::Device, typename Function, typename T>
+template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>
 void portableReduce([[maybe_unused]] const char *name, int startb, int stopb, int starta,
                     int stopa, int startz, int stopz, int starty, int stopy, int startx,
                     int stopx, Function function, T &reduced) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Policy5D =
-      Kokkos::MDRangePolicy<typename PortsOfCall::ExecSpace<E>::type, Kokkos::Rank<5>>;
+  using Policy5D = Kokkos::MDRangePolicy<E, Kokkos::Rank<5>>;
   Kokkos::parallel_reduce(name,
                           Policy5D({startb, starta, startz, starty, startx},
                                    {stopb, stopa, stopz, stopy, stopx}),
@@ -451,14 +415,11 @@ void portableReduce([[maybe_unused]] const char *name, int startb, int stopb, in
 #endif
 }
 
-template <typename... Args>
-void portableReduce([[maybe_unused]] const char *name, PortsOfCall::Exec e,
+template <typename E, typename = std::enable_if_t<!std::is_arithmetic_v<E>>,
+          typename... Args>
+void portableReduce([[maybe_unused]] const char *name, [[maybe_unused]] E e,
                     Args &&...args) {
-  if (e == PortsOfCall::Exec::Device) {
-    portableReduce<PortsOfCall::Exec::Device>(name, std::forward<Args>(args)...);
-  } else { // host
-    portableReduce<PortsOfCall::Exec::Host>(name, std::forward<Args>(args)...);
-  }
+  portableReduce<E>(name, std::forward<Args>(args)...);
 }
 
 #endif // PORTABILITY_HPP

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -2,7 +2,7 @@
 #define _PORTABILITY_HPP_
 
 // ========================================================================================
-// © (or copyright) 2019-2024. Triad National Security, LLC. All rights
+// © (or copyright) 2019-2026. Triad National Security, LLC. All rights
 // reserved.  This program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which is
 // operated by Triad National Security, LLC for the U.S.  Department of

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -221,12 +221,13 @@ void portableCopyToHost(T *const to, T const *const from, size_t const size_byte
   return;
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function>
-void portableFor([[maybe_unused]] const char *name, int start, int stop,
-                 Function function) {
+template <typename E, typename Function,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                 int start, int stop, const Function &function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using policy = Kokkos::RangePolicy<E>;
-  Kokkos::parallel_for(name, policy(start, stop), function);
+  Kokkos::parallel_for(name, policy(e, start, stop), function);
 #else
   for (int i = start; i < stop; i++) {
     function(i);
@@ -234,12 +235,13 @@ void portableFor([[maybe_unused]] const char *name, int start, int stop,
 #endif
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function>
-void portableFor([[maybe_unused]] const char *name, int starty, int stopy, int startx,
-                 int stopx, Function function) {
+template <typename E, typename Function,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                 int starty, int stopy, int startx, int stopx, const Function &function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy2D = Kokkos::MDRangePolicy<E, Kokkos::Rank<2>>;
-  Kokkos::parallel_for(name, Policy2D({starty, startx}, {stopy, stopx}), function);
+  Kokkos::parallel_for(name, Policy2D(e, {starty, startx}, {stopy, stopx}), function);
 #else
   for (int iy = starty; iy < stopy; iy++) {
     for (int ix = startx; ix < stopx; ix++) {
@@ -249,13 +251,15 @@ void portableFor([[maybe_unused]] const char *name, int starty, int stopy, int s
 #endif
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function>
-void portableFor([[maybe_unused]] const char *name, int startz, int stopz, int starty,
-                 int stopy, int startx, int stopx, Function function) {
+template <typename E, typename Function,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                 int startz, int stopz, int starty, int stopy, int startx, int stopx,
+                 const Function &function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy3D = Kokkos::MDRangePolicy<E, Kokkos::Rank<3>>;
-  Kokkos::parallel_for(name, Policy3D({startz, starty, startx}, {stopz, stopy, stopx}),
-                       function);
+  Kokkos::parallel_for(
+      name, Policy3D(space, {startz, starty, startx}, {stopz, stopy, stopx}), function);
 #else
   for (int iz = startz; iz < stopz; iz++) {
     for (int iy = starty; iy < stopy; iy++) {
@@ -267,14 +271,16 @@ void portableFor([[maybe_unused]] const char *name, int startz, int stopz, int s
 #endif
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function>
-void portableFor([[maybe_unused]] const char *name, int starta, int stopa, int startz,
-                 int stopz, int starty, int stopy, int startx, int stopx,
-                 Function function) {
+template <typename E = PortsOfCall::Exec::Device, typename Function,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                 int starta, int stopa, int startz, int stopz, int starty, int stopy,
+                 int startx, int stopx, const Function &function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy4D = Kokkos::MDRangePolicy<E, Kokkos::Rank<4>>;
   Kokkos::parallel_for(
-      name, Policy4D({starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
+      name,
+      Policy4D(space, {starta, startz, starty, startx}, {stopa, stopz, stopy, stopx}),
       function);
 #else
   for (int ia = starta; ia < stopa; ia++) {
@@ -289,14 +295,15 @@ void portableFor([[maybe_unused]] const char *name, int starta, int stopa, int s
 #endif
 }
 
-template <typename E = PortsOfCall::Exec::Device, typename Function>
-void portableFor([[maybe_unused]] const char *name, int startb, int stopb, int starta,
-                 int stopa, int startz, int stopz, int starty, int stopy, int startx,
-                 int stopx, Function function) {
+template <typename E, typename Function,
+          typename = std::enable_if_t<!std::is_arithmetic_v<E>>>
+void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] const E &e,
+                 int startb, int stopb, int starta, int stopa, int startz, int stopz,
+                 int starty, int stopy, int startx, int stopx, const Function &function) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy5D = Kokkos::MDRangePolicy<E, Kokkos::Rank<5>>;
   Kokkos::parallel_for(name,
-                       Policy5D({startb, starta, startz, starty, startx},
+                       Policy5D(space, {startb, starta, startz, starty, startx},
                                 {stopb, stopa, stopz, stopy, stopx}),
                        function);
 #else
@@ -314,11 +321,10 @@ void portableFor([[maybe_unused]] const char *name, int startb, int stopb, int s
 #endif
 }
 
-template <typename E, typename = std::enable_if_t<!std::is_arithmetic_v<E>>,
-          typename... Args>
-void portableFor([[maybe_unused]] const char *name, [[maybe_unused]] E e,
-                 Args &&...args) {
-  portableFor<E>(name, std::forward<Args>(args)...);
+template <typename Head, typename... Tail,
+          typename = std::enable_if_t<std::is_arithmetic_v<Head>>>
+void portableFor([[maybe_unused]] const char *name, Head &&h, Tail&&...tail) {
+  portableFor(name, PortsOfCall::Exec::Device(), h, std::forward<Tail>(tail)...);
 }
 
 template <typename E = PortsOfCall::Exec::Device, typename Function, typename T>

--- a/test/test_portability.cpp
+++ b/test/test_portability.cpp
@@ -1,4 +1,4 @@
-// © (or copyright) 2019-2024. Triad National Security, LLC. All rights
+// © (or copyright) 2019-2026. Triad National Security, LLC. All rights
 // reserved.  This program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which is
 // operated by Triad National Security, LLC for the U.S.  Department of

--- a/test/test_portability.cpp
+++ b/test/test_portability.cpp
@@ -11,6 +11,8 @@
 // copies to the public, perform publicly and display publicly, and to
 // permit others to do so.
 
+// This file was generated in part with generative AI
+
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
 #include <vector>

--- a/test/test_portability.cpp
+++ b/test/test_portability.cpp
@@ -186,3 +186,54 @@ TEST_CASE("PORTABLE_FENCE properly synchronizes execution after a portableFor",
   // free device memory
   PORTABLE_FREE(d_data);
 }
+
+TEST_CASE("portableFor and portableReduce accept an explicit execution-space selector",
+          "[portableFor][portableReduce]") {
+  constexpr int N = 32;
+  constexpr size_t Nb = N * sizeof(int);
+
+  SECTION("Host execution selector uses host-accessible storage") {
+    std::vector<int> values(N, 0);
+    int *const values_ptr = values.data();
+
+    portableFor<PortsOfCall::Exec::Host>(
+        "fill on host", 0, N, PORTABLE_LAMBDA(const int i) { values_ptr[i] = i + 1; });
+
+    int sum = 0;
+    portableReduce<PortsOfCall::Exec::Host>(
+        "sum on host", 0, N,
+        PORTABLE_LAMBDA(const int i, int &local) { local += values_ptr[i]; }, sum);
+
+    REQUIRE(sum == (N * (N + 1)) / 2);
+  }
+
+  SECTION("Device execution selector uses portable storage") {
+    int *const values_ptr = static_cast<int *>(PORTABLE_MALLOC(Nb));
+
+    portableFor<PortsOfCall::Exec::Device>(
+        "fill on device", 0, N, PORTABLE_LAMBDA(const int i) { values_ptr[i] = i + 1; });
+
+    PORTABLE_FENCE("Fence after explicit device fill");
+
+    int sum = 0;
+    portableReduce<PortsOfCall::Exec::Device>(
+        "sum on device", 0, N,
+        PORTABLE_LAMBDA(const int i, int &local) { local += values_ptr[i]; }, sum);
+
+    REQUIRE(sum == (N * (N + 1)) / 2);
+
+    portableFor<PortsOfCall::Exec::Device>(
+        "adjust on device", 0, N, PORTABLE_LAMBDA(const int i) { values_ptr[i] += 1; });
+
+    PORTABLE_FENCE("Fence after explicit device adjust");
+
+    sum = 0;
+    portableReduce<PortsOfCall::Exec::Device>(
+        "sum adjusted device values", 0, N,
+        PORTABLE_LAMBDA(const int i, int &local) { local += values_ptr[i]; }, sum);
+
+    REQUIRE(sum == (N * (N + 1)) / 2 + N);
+
+    PORTABLE_FREE(values_ptr);
+  }
+}

--- a/test/test_portability.cpp
+++ b/test/test_portability.cpp
@@ -199,12 +199,12 @@ TEST_CASE("portableFor and portableReduce accept an explicit execution-space sel
     int *const values_ptr = values.data();
 
     portableFor(
-        "fill on host", PortsOfCall::Exec::Host, 0, N,
+        "fill on host", PortsOfCall::Exec::Host(), 0, N,
         PORTABLE_LAMBDA(const int i) { values_ptr[i] = i + 1; });
 
     int sum = 0;
     portableReduce(
-        "sum on host", PortsOfCall::Exec::Host, 0, N,
+        "sum on host", PortsOfCall::Exec::Host(), 0, N,
         PORTABLE_LAMBDA(const int i, int &local) { local += values_ptr[i]; }, sum);
 
     REQUIRE(sum == (N * (N + 1)) / 2);

--- a/test/test_portability.cpp
+++ b/test/test_portability.cpp
@@ -213,26 +213,28 @@ TEST_CASE("portableFor and portableReduce accept an explicit execution-space sel
   SECTION("Device execution selector uses portable storage") {
     int *const values_ptr = static_cast<int *>(PORTABLE_MALLOC(Nb));
 
-    portableFor<PortsOfCall::Exec::Device>(
-        "fill on device", 0, N, PORTABLE_LAMBDA(const int i) { values_ptr[i] = i + 1; });
+    portableFor(
+        "fill on device", PortsOfCall::Exec::Device(), 0, N,
+        PORTABLE_LAMBDA(const int i) { values_ptr[i] = i + 1; });
 
     PORTABLE_FENCE("Fence after explicit device fill");
 
     int sum = 0;
-    portableReduce<PortsOfCall::Exec::Device>(
-        "sum on device", 0, N,
+    portableReduce(
+        "sum on device", PortsOfCall::Exec::Device(), 0, N,
         PORTABLE_LAMBDA(const int i, int &local) { local += values_ptr[i]; }, sum);
 
     REQUIRE(sum == (N * (N + 1)) / 2);
 
-    portableFor<PortsOfCall::Exec::Device>(
-        "adjust on device", 0, N, PORTABLE_LAMBDA(const int i) { values_ptr[i] += 1; });
+    portableFor(
+        "adjust on device", PortsOfCall::Exec::Device(), 0, N,
+        PORTABLE_LAMBDA(const int i) { values_ptr[i] += 1; });
 
     PORTABLE_FENCE("Fence after explicit device adjust");
 
     sum = 0;
-    portableReduce<PortsOfCall::Exec::Device>(
-        "sum adjusted device values", 0, N,
+    portableReduce(
+        "sum adjusted device values", PortsOfCall::Exec::Device(), 0, N,
         PORTABLE_LAMBDA(const int i, int &local) { local += values_ptr[i]; }, sum);
 
     REQUIRE(sum == (N * (N + 1)) / 2 + N);

--- a/test/test_portability.cpp
+++ b/test/test_portability.cpp
@@ -198,12 +198,13 @@ TEST_CASE("portableFor and portableReduce accept an explicit execution-space sel
     std::vector<int> values(N, 0);
     int *const values_ptr = values.data();
 
-    portableFor<PortsOfCall::Exec::Host>(
-        "fill on host", 0, N, PORTABLE_LAMBDA(const int i) { values_ptr[i] = i + 1; });
+    portableFor(
+        "fill on host", PortsOfCall::Exec::Host, 0, N,
+        PORTABLE_LAMBDA(const int i) { values_ptr[i] = i + 1; });
 
     int sum = 0;
-    portableReduce<PortsOfCall::Exec::Host>(
-        "sum on host", 0, N,
+    portableReduce(
+        "sum on host", PortsOfCall::Exec::Host, 0, N,
         PORTABLE_LAMBDA(const int i, int &local) { local += values_ptr[i]; }, sum);
 
     REQUIRE(sum == (N * (N + 1)) / 2);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This change is motivated by two issues in singularity-eos:
1. @rbberger indicates that Flecsi will at some point want to be able to choose how `portableFor` calls and the singularity-eos vector API calls are launched to launch on host or device, depending on context.
2. In riot we are hitting this right now with Python. In particular, we want to build for a GPU system but enable the Python API to function with CPU calls. https://github.com/lanl/singularity-eos/issues/628

As a first step towards fixing that, I thread through `ports-of-call` portable functions the ability to select an execution space. It's really only implemented for Kokkos and serial backends at the moment. @adamdempsey90 this probably also relates to your memory pool MR #105 .

I used codex to eliminate some of the drudgery of this MR. Which forced me to think through contribution rules for agentic-contributed code. Those rules are also in this MR. Feedback welcome.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [x] Install test passes.
- [x] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
- [x] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [x] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.
