### PR TITLE
add tests to robust utils, update to C++20, add Robust::is_normal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ simple_test_cuda
 __pycache__
 .aider*
 extern
+.codex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ target_include_directories(
   ${POCLIB} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-target_compile_features(${POCLIB} INTERFACE cxx_std_17)
+target_compile_features(${POCLIB} INTERFACE cxx_std_20)
 
 # TESTING
 # ----------------------------------------

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -182,6 +182,8 @@ robust_utils.hpp
 robustness, especially around floating point numbers. The available
 functionality is contained in the namespace ``PortsOfCall::Robust`` and includes:
 
+* ``constexpr bool is_normal(const T val, const T )`` returns whether or not a number is normal
+* ``constexpr bool is_normal_or_zero(const T val)`` returns whether or not a float is normal or zero
 * ``constexpr auto SMALL<T>()`` returns a small number of type ``T``.
 * ``constexpr auto EPS<T>()`` returns a value of type ``T`` close to machine epsilon.
 * ``constexpr auto min_exp_arg<T>()`` returns the smallest safe value of type ``T`` to pass into an exponent.

--- a/doc/sphinx/src/using.rst
+++ b/doc/sphinx/src/using.rst
@@ -418,9 +418,10 @@ C++20.
 span.hpp
 
 
-``PortsOfCall::span`` is implements ``std::span`` for C++17 (uses native implmentation in C++20) 
-as a view over contiguous data. ``span`` may have compile-time static extent, or a dynamic extent. 
-``span`` provides iterator functions similar to containers.
+``PortsOfCall::span`` is implements ``std::span`` for C++17 as a view
+over contiguous data. ``span`` may have compile-time static extent, or
+a dynamic extent.  ``span`` provides iterator functions similar to
+containers.
 
 .. code-block:: cpp
   
@@ -434,7 +435,10 @@ as a view over contiguous data. ``span`` may have compile-time static extent, or
 ``span::subspan`` returns a span over a subrange. Element access uses ``span::operator[]``. For 
 more information, see `C++ reference page <https://en.cppreference.com/w/cpp/container/span>`_.
 
+.. note::
 
+  Note that now that we rely on C++20, ``PortsOfCall::span`` may
+  eventually be replaced by ``std::span``.
 
 static_vector.hpp
 ^^^^^^^^^^^^^^^^^

--- a/ports-of-call/robust_utils.hpp
+++ b/ports-of-call/robust_utils.hpp
@@ -18,6 +18,7 @@
 #define PORTS_OF_CALL_ROBUST_UTILS_HPP_
 
 #include <algorithm>
+#include <concepts>
 #include <cmath>
 #include <limits>
 #include <ports-of-call/portability.hpp>

--- a/ports-of-call/robust_utils.hpp
+++ b/ports-of-call/robust_utils.hpp
@@ -25,9 +25,8 @@
 namespace PortsOfCall {
 namespace Robust {
 
-template <typename T = Real,
-          typename std::enable_if<std::is_integral<T>::value ||
-                                  std::is_floating_point<T>::value>::type * = nullptr>
+template <typename T = Real>
+  requires(std::integral<T> || std::floating_point<T>)
 PORTABLE_FORCEINLINE_FUNCTION constexpr bool is_normal(const T val,
                                                        const T factor = T{1}) {
   if constexpr (std::is_integral_v<T>) {
@@ -39,9 +38,8 @@ PORTABLE_FORCEINLINE_FUNCTION constexpr bool is_normal(const T val,
   }
 }
 
-template <typename T = Real,
-          typename std::enable_if<std::is_integral<T>::value ||
-                                  std::is_floating_point<T>::value>::type * = nullptr>
+template <typename T = Real>
+  requires(std::integral<T> || std::floating_point<T>)
 PORTABLE_FORCEINLINE_FUNCTION constexpr bool is_normal_or_zero(const T val,
                                                                const T factor = T{1}) {
   return (val == T{0}) || is_normal(val, factor);

--- a/ports-of-call/robust_utils.hpp
+++ b/ports-of-call/robust_utils.hpp
@@ -43,7 +43,7 @@ template <typename T = Real>
   requires(std::integral<T> || std::floating_point<T>)
 PORTABLE_FORCEINLINE_FUNCTION constexpr bool is_normal_or_zero(const T val,
                                                                const T factor = T{1}) {
-  return (val == T{0}) || is_normal(val, factor);
+  return  is_normal(val, factor) || (val == T{0});
 }
 
 template <typename T = Real>

--- a/ports-of-call/robust_utils.hpp
+++ b/ports-of-call/robust_utils.hpp
@@ -12,15 +12,40 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
+// This file created with the assistance of generative AI
+
 #ifndef PORTS_OF_CALL_ROBUST_UTILS_HPP_
 #define PORTS_OF_CALL_ROBUST_UTILS_HPP_
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <ports-of-call/portability.hpp>
 
 namespace PortsOfCall {
 namespace Robust {
+
+template <typename T = Real,
+          typename std::enable_if<std::is_integral<T>::value ||
+                                  std::is_floating_point<T>::value>::type * = nullptr>
+PORTABLE_FORCEINLINE_FUNCTION constexpr bool is_normal(const T val,
+                                                       const T factor = T{1}) {
+  if constexpr (std::is_integral_v<T>) {
+    return true;
+  } else {
+    using limits = std::numeric_limits<T>;
+    const T abs_val = (val < T{0}) ? -val : val;
+    return ((abs_val >= limits::min()) && (abs_val * factor <= limits::max()));
+  }
+}
+
+template <typename T = Real,
+          typename std::enable_if<std::is_integral<T>::value ||
+                                  std::is_floating_point<T>::value>::type * = nullptr>
+PORTABLE_FORCEINLINE_FUNCTION constexpr bool is_normal_or_zero(const T val,
+                                                               const T factor = T{1}) {
+  return (val == T{0}) || is_normal(val, factor);
+}
 
 template <typename T = Real>
 PORTABLE_FORCEINLINE_FUNCTION constexpr auto SMALL() {
@@ -59,9 +84,9 @@ PORTABLE_FORCEINLINE_FUNCTION int sgn(const T &val) {
 
 template <typename A, typename B>
 PORTABLE_FORCEINLINE_FUNCTION auto ratio(const A &a, const B &b) {
-  B mask = static_cast<B>(std::abs(b) < SMALL());
+  B mask = static_cast<B>(std::abs(b) < SMALL<B>());
   B denom = mask * sgn(b) * SMALL<B>() + (1 - mask) * b;
-  return a / (b + sgn(b) * SMALL<B>());
+  return a / denom;
 }
 
 template <typename T>

--- a/ports-of-call/robust_utils.hpp
+++ b/ports-of-call/robust_utils.hpp
@@ -83,8 +83,8 @@ PORTABLE_FORCEINLINE_FUNCTION int sgn(const T &val) {
 
 template <typename A, typename B>
 PORTABLE_FORCEINLINE_FUNCTION auto ratio(const A &a, const B &b) {
-  B mask = static_cast<B>(std::abs(b) < SMALL<B>());
-  B denom = mask * sgn(b) * SMALL<B>() + (1 - mask) * b;
+const B mask = static_cast<B>(std::abs(b) < SMALL<B>());
+const B denom = mask * sgn(b) * SMALL<B>() + (1 - mask) * b;
   return a / denom;
 }
 

--- a/ports-of-call/span.hpp
+++ b/ports-of-call/span.hpp
@@ -2,7 +2,7 @@
 #define PORTS_OF_CALL_SPAN_HH_
 
 // ========================================================================================
-// © (or copyright) 2019-2024. Triad National Security, LLC. All rights
+// © (or copyright) 2019-2026. Triad National Security, LLC. All rights
 // reserved.  This program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which is
 // operated by Triad National Security, LLC for the U.S.  Department of
@@ -26,24 +26,12 @@
 
 #include "robust_utils.hpp"
 
-#if defined(__cpp_lib_span) // do we already have std::span?
-#define PORTS_OF_CALL_USES_STD_SPAN
-
-#include <span>
-namespace PortsOfCall::span {
-
-using std::span;
-
-} // namespace PortsOfCall::span
-
-#else
-#ifdef PORTS_OF_CALL_USES_STD_SPAN
-#undef PORTS_OF_CALL_USES_STD_SPAN
-#endif
-
 #define span_REQUIRES(...) typename std::enable_if<((__VA_ARGS__)), int>::type = 0
 
 #define span_EXPECTS(...) assert((__VA_ARGS__))
+
+// TODO(JMM): Check if C++20 span is ok on device with C++20. If it is
+// not, continue to use ports-of-call span
 
 namespace PortsOfCall::span {
 
@@ -600,5 +588,4 @@ class tuple_element<I, PortsOfCall::span::span<ElementType, Extent>> {
 
 } // end namespace std
 
-#endif // __cpp_lib_span
 #endif // PORTS_OF_CALL_SPAN_HH_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,6 +110,7 @@ target_sources(test_portsofcall
     test_portability.cpp
     test_array.cpp
     test_math_utils.cpp
+    test_robust_utils.cpp
     test_span.cpp
     test_static_vector.cpp
     test_static_vector_iterator.cpp

--- a/test/test_math_utils.cpp
+++ b/test/test_math_utils.cpp
@@ -68,8 +68,8 @@ TEST_CASE("power", "[math_utils]") {
 TEST_CASE("expm1", "[math_utils]") {
   using Catch::Matchers::WithinRel;
   using PortsOfCall::Math::expm1;
-  CHECK_THAT(expm1(0.0),WithinRel(0.0));
+  CHECK_THAT(expm1(0.0), WithinRel(0.0));
   double reference = std::exp(1.0) - 1.0;
-  CHECK_THAT(expm1(1.0),WithinRel(reference));
-  CHECK_THAT(expm1(1e-15)/1e-15,WithinRel(1.0));
+  CHECK_THAT(expm1(1.0), WithinRel(reference));
+  CHECK_THAT(expm1(1e-15) / 1e-15, WithinRel(1.0));
 }

--- a/test/test_robust_utils.cpp
+++ b/test/test_robust_utils.cpp
@@ -1,0 +1,130 @@
+#include <ports-of-call/robust_utils.hpp>
+
+#ifndef CATCH_CONFIG_FAST_COMPILE
+#define CATCH_CONFIG_FAST_COMPILE
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#endif
+
+#include <cmath>
+#include <limits>
+
+// This file made with the assistance of generative AI
+
+namespace {
+
+template <typename T>
+PORTABLE_FORCEINLINE_FUNCTION bool within_rel(const T lhs, const T rhs,
+                                              const T rel_tol = T{1.0e-12}) {
+  const T lhs_abs = lhs < T{0} ? -lhs : lhs;
+  const T rhs_abs = rhs < T{0} ? -rhs : rhs;
+  const T scale = lhs_abs > rhs_abs ? lhs_abs : rhs_abs;
+  const T diff = lhs > rhs ? lhs - rhs : rhs - lhs;
+  return diff <= rel_tol * (scale > T{1} ? scale : T{1});
+}
+
+} // namespace
+
+TEST_CASE("robust_utils predicates", "[robust_utils]") {
+  namespace Robust = PortsOfCall::Robust;
+
+  CHECK(Robust::is_normal(7));
+  CHECK(Robust::is_normal(1.0));
+  CHECK_FALSE(Robust::is_normal(0.0));
+  CHECK_FALSE(Robust::is_normal(std::numeric_limits<double>::min() / 2.0));
+  CHECK_FALSE(Robust::is_normal(std::numeric_limits<double>::max(), 2.0));
+
+  CHECK(Robust::is_normal_or_zero(0.0));
+  CHECK(Robust::is_normal_or_zero(1.0));
+  CHECK_FALSE(Robust::is_normal_or_zero(std::numeric_limits<double>::min() / 2.0));
+
+  CHECK_FALSE(Robust::check_nonnegative(-1));
+  CHECK(Robust::check_nonnegative(0));
+  CHECK(Robust::check_nonnegative(5));
+  CHECK(Robust::check_nonnegative(5u));
+}
+
+TEST_CASE("robust_utils numeric helpers", "[robust_utils]") {
+  using Catch::Matchers::WithinRel;
+  namespace Robust = PortsOfCall::Robust;
+
+  CHECK(Robust::SMALL<double>() == 10 * std::numeric_limits<double>::min());
+  CHECK(Robust::EPS<double>() == 10 * std::numeric_limits<double>::epsilon());
+  CHECK_THAT(Robust::min_exp_arg<double>(),
+             WithinRel((std::numeric_limits<double>::min_exponent - 1) * std::log(2.0)));
+  CHECK_THAT(Robust::max_exp_arg<double>(),
+             WithinRel(std::numeric_limits<double>::max_exponent * std::log(2.0)));
+
+  CHECK_THAT(Robust::make_positive(-1.0), WithinRel(Robust::EPS<double>()));
+  CHECK_THAT(Robust::make_positive(2.5), WithinRel(2.5));
+
+  CHECK_THAT(Robust::make_bounded(-1.0, 0.0, 2.0), WithinRel(Robust::EPS<double>()));
+  CHECK_THAT(Robust::make_bounded(1.5, 0.0, 2.0), WithinRel(1.5));
+  CHECK_THAT(Robust::make_bounded(3.0, 0.0, 2.0),
+             WithinRel(2.0 * (1.0 - Robust::EPS<double>())));
+
+  CHECK(Robust::sgn(-3) == -1);
+  CHECK(Robust::sgn(0) == 1);
+  CHECK(Robust::sgn(3) == 1);
+
+  CHECK_THAT(Robust::ratio(6.0, 3.0), WithinRel(2.0));
+  CHECK(Robust::ratio(0.0, 0.0) == 0.0);
+  CHECK(Robust::ratio(1.0, 0.0) > 1.0e300);
+
+  CHECK(Robust::safe_arg_exp(Robust::min_exp_arg<double>() - 1.0) == 0.0);
+  CHECK(Robust::safe_arg_exp(Robust::max_exp_arg<double>() + 1.0) ==
+        std::numeric_limits<double>::infinity());
+  CHECK_THAT(Robust::safe_arg_exp(1.0), WithinRel(std::exp(1.0)));
+}
+
+TEST_CASE("robust_utils (GPU)", "[robust_utils][GPU]") {
+  int failures = 0;
+  portableReduce(
+      "robust utils device", 0, 1,
+      PORTABLE_LAMBDA(const int /*i*/, int &local_failures) {
+        local_failures += !PortsOfCall::Robust::is_normal(7);
+        local_failures += !PortsOfCall::Robust::is_normal(1.0);
+        local_failures += PortsOfCall::Robust::is_normal(0.0);
+        local_failures +=
+            PortsOfCall::Robust::is_normal(std::numeric_limits<double>::min() / 2.0);
+        local_failures +=
+            PortsOfCall::Robust::is_normal(std::numeric_limits<double>::max(), 2.0);
+        local_failures += !PortsOfCall::Robust::is_normal_or_zero(0.0);
+        local_failures += !PortsOfCall::Robust::check_nonnegative(5u);
+        local_failures += PortsOfCall::Robust::check_nonnegative(-1);
+        local_failures += (PortsOfCall::Robust::SMALL<double>() !=
+                           10 * std::numeric_limits<double>::min());
+        local_failures += (PortsOfCall::Robust::EPS<double>() !=
+                           10 * std::numeric_limits<double>::epsilon());
+        local_failures +=
+            !within_rel(PortsOfCall::Robust::min_exp_arg<double>(),
+                        (std::numeric_limits<double>::min_exponent - 1) * M_LN2);
+        local_failures += !within_rel(PortsOfCall::Robust::max_exp_arg<double>(),
+                                      std::numeric_limits<double>::max_exponent * M_LN2);
+        local_failures += !within_rel(PortsOfCall::Robust::make_positive(-1.0),
+                                      PortsOfCall::Robust::EPS<double>());
+        local_failures += !within_rel(PortsOfCall::Robust::make_positive(2.5), 2.5);
+        local_failures += !within_rel(PortsOfCall::Robust::make_bounded(-1.0, 0.0, 2.0),
+                                      PortsOfCall::Robust::EPS<double>());
+        local_failures +=
+            !within_rel(PortsOfCall::Robust::make_bounded(1.5, 0.0, 2.0), 1.5);
+        local_failures += !within_rel(PortsOfCall::Robust::make_bounded(3.0, 0.0, 2.0),
+                                      2.0 * (1.0 - PortsOfCall::Robust::EPS<double>()));
+        local_failures += (PortsOfCall::Robust::sgn(-3) != -1);
+        local_failures += (PortsOfCall::Robust::sgn(0) != 1);
+        local_failures += (PortsOfCall::Robust::sgn(3) != 1);
+        local_failures += !within_rel(PortsOfCall::Robust::ratio(6.0, 3.0), 2.0);
+        local_failures += (PortsOfCall::Robust::ratio(0.0, 0.0) != 0.0);
+        local_failures += !(PortsOfCall::Robust::ratio(1.0, 0.0) > 1.0e300);
+        local_failures += (PortsOfCall::Robust::safe_arg_exp(
+                               PortsOfCall::Robust::min_exp_arg<double>() - 1.0) != 0.0);
+        local_failures += (PortsOfCall::Robust::safe_arg_exp(
+                               PortsOfCall::Robust::max_exp_arg<double>() + 1.0) !=
+                           std::numeric_limits<double>::infinity());
+        local_failures +=
+            !within_rel(PortsOfCall::Robust::safe_arg_exp(1.0), std::exp(1.0));
+      },
+      failures);
+
+  REQUIRE(failures == 0);
+}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR is a bit of a cleanup. I:
1. Update us to C++20 as we discussed in the call
2. Add tests for robust_utils, which were previously not present. This process unearthed some bugs, which are fixed.
3. Add `Robust::is_normal` and `Robust::is_normal_or_zero`, which I move out of [this MR in singularity-eos](https://github.com/lanl/singularity-eos/pull/637). The main motivation here is that `std::is_normal` is not portable. This provides a portable alternative. I also take the opportunity to start using concepts now that C++20 is supported. I strategically upgrade that where appropriate.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Any changes to code are appropriately documented.
- [x] Code is formatted.
- [ ] Install test passes.
- [x] Docs build.
- [ ] If preparing for a new release, update the version in cmake.
- [x] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.